### PR TITLE
Improved random

### DIFF
--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -953,6 +953,8 @@ mod tests {
                 "device_name",
                 "min_brightness",
                 "max_brightness",
+                "min_saturation",
+                "max_saturation",
                 "transition",
                 "strobe_interval",
                 "outbound_device_updates.min_interval_ms",

--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -596,13 +596,63 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
             "random",
             "Random",
             "Expose a virtual color sensor that emits a random color every second.",
-            vec![text_config_field(
-                "device_name",
-                "Device name",
-                true,
-                "Display name for the virtual random color device.",
-                Some("Random colors"),
-            )],
+            vec![
+                text_config_field(
+                    "device_name",
+                    "Device name",
+                    true,
+                    "Display name for the virtual random color device.",
+                    Some("Random colors"),
+                ),
+                number_config_field(
+                    "min_brightness",
+                    "Minimum brightness",
+                    false,
+                    "Lower bound for random brightness values from 0 to 1.",
+                    (Some(0.0), Some(1.0), Some(0.1)),
+                    Some("0.4"),
+                ),
+                number_config_field(
+                    "max_brightness",
+                    "Maximum brightness",
+                    false,
+                    "Upper bound for random brightness values from 0 to 1.",
+                    (Some(0.0), Some(1.0), Some(0.1)),
+                    Some("0.8"),
+                ),
+                number_config_field(
+                    "min_saturation",
+                    "Minimum saturation",
+                    false,
+                    "Lower bound for random saturation values from 0 to 1.",
+                    (Some(0.0), Some(1.0), Some(0.1)),
+                    Some("0.4"),
+                ),
+                number_config_field(
+                    "max_saturation",
+                    "Maximum saturation",
+                    false,
+                    "Upper bound for random saturation values from 0 to 1.",
+                    (Some(0.0), Some(1.0), Some(0.1)),
+                    Some("0.7"),
+                ),
+                number_config_field(
+                    "transition",
+                    "Transition",
+                    false,
+                    "Transition duration in seconds applied to each random color update.",
+                    (Some(0.0), Some(10.0), Some(0.1)),
+                    Some("0.6"),
+                ),
+                number_config_field(
+                    "strobe_interval",
+                    "Strobe interval",
+                    false,
+                    "Polling interval in milliseconds between random color updates.",
+                    (Some(20.0), None, Some(100.0)),
+                    Some("1000"),
+                ),
+            ],
         )),
         _ => None,
     }
@@ -886,5 +936,27 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(color_fields, vec!["day_color", "night_color"]);
+    }
+
+    #[test]
+    fn random_schema_exposes_random_config_fields() {
+        let schema = integration_config_schema("random").expect("random schema should exist");
+        let keys = schema
+            .fields
+            .iter()
+            .map(|field| field.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            vec![
+                "device_name",
+                "min_brightness",
+                "max_brightness",
+                "transition",
+                "strobe_interval",
+                "outbound_device_updates.min_interval_ms",
+            ]
+        );
     }
 }

--- a/server/src/integrations/random/mod.rs
+++ b/server/src/integrations/random/mod.rs
@@ -19,13 +19,35 @@ use tokio::time;
 #[derive(Clone, Debug, Deserialize)]
 pub struct RandomConfig {
     device_name: String,
+    min_brightness: Option<f32>,
+    max_brightness: Option<f32>,
+    min_saturation: Option<f32>,
+    max_saturation: Option<f32>,
+    // transition is the number of seconds
+    // it takes for the device to transition from one state to another.
+    transition: Option<f32>,
+    // strobe_interval is the number of milliseconds between
+    // each strobe when the device is in strobe mode.
+    // If None, defaults to 1000 milliseconds.
+    strobe_interval: Option<u64>,
 }
 
-#[derive(Clone)]
 pub struct Random {
     id: IntegrationId,
     config: RandomConfig,
     event_tx: TxEventChannel,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Clone for Random {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id.clone(),
+            config: self.config.clone(),
+            event_tx: self.event_tx.clone(),
+            handle: None,
+        }
+    }
 }
 
 #[async_trait]
@@ -43,6 +65,7 @@ impl Integration for Random {
             id: id.clone(),
             config,
             event_tx,
+            handle: None,
         })
     }
 
@@ -59,24 +82,47 @@ impl Integration for Random {
 
         // FIXME: can we restructure the integrations / devices systems such
         // that polling is not needed here?
-        tokio::spawn(async { poll_sensor(random).await });
+        // store the join handle in self
+        self.handle = Some(tokio::spawn(async { poll_sensor(random).await }));
 
         Ok(())
     }
+
+    // stop is needed so we can stop the interval tick that 
+    // is created by start. 
+    async fn stop(&mut self) -> Result<()> {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+
+        Ok(())
+    }
+
 }
 
-fn get_random_color() -> DeviceColor {
+fn get_random_color(random: &Random) -> DeviceColor {
     let mut rng = rand::thread_rng();
 
-    let r: u8 = rng.gen();
-    let g: u8 = rng.gen();
-    let b: u8 = rng.gen();
+    // h should be between 0 and 360
+    let h: u16 = rng.gen_range(0..360);
+    let min_s = random.config.min_saturation.unwrap_or(0.0).clamp(0.2, 1.0);
+    let max_s = random.config.max_saturation.unwrap_or(1.0).clamp(0.2, 1.0);
+    let s: f32 = rng.gen_range(min_s..=max_s);
 
-    DeviceColor::new_from_rgb(r, g, b)
+    DeviceColor::new_from_hs(h, s)
+}
+
+fn get_random_brightness(random: &Random) -> f32 {
+    let mut rng = rand::thread_rng();
+
+    let min = random.config.min_brightness.unwrap_or(0.0).clamp(0.0, 1.0);
+    let max = random.config.max_brightness.unwrap_or(1.0).clamp(0.0, 1.0);
+
+    rng.gen_range(min..=max)
 }
 
 async fn poll_sensor(random: Random) {
-    let poll_rate = Duration::from_millis(1000);
+    let poll_rate = Duration::from_millis(random.config.strobe_interval.unwrap_or(1000).clamp(20, 10000));
     let mut interval = time::interval(poll_rate);
 
     loop {
@@ -93,9 +139,11 @@ async fn poll_sensor(random: Random) {
 fn mk_random_device(random: &Random) -> Device {
     let state = DeviceData::Sensor(SensorDevice::Color(ControllableState {
         power: true,
-        color: Some(get_random_color()),
-        brightness: Some(OrderedFloat(1.0)),
-        transition: Some(OrderedFloat(0.6)),
+        color: Some(get_random_color(random)),
+        brightness: Some(OrderedFloat(get_random_brightness(random))),
+        transition: Some(OrderedFloat(
+            random.config.transition.unwrap_or(0.6).clamp(0.0, 10.0),
+        )),
     }));
 
     Device {

--- a/server/src/integrations/random/mod.rs
+++ b/server/src/integrations/random/mod.rs
@@ -88,8 +88,8 @@ impl Integration for Random {
         Ok(())
     }
 
-    // stop is needed so we can stop the interval tick that 
-    // is created by start. 
+    // stop is needed so we can stop the interval tick that
+    // is created by start.
     async fn stop(&mut self) -> Result<()> {
         if let Some(handle) = &self.handle {
             handle.abort();
@@ -97,7 +97,6 @@ impl Integration for Random {
 
         Ok(())
     }
-
 }
 
 fn get_random_color(random: &Random) -> DeviceColor {
@@ -122,7 +121,13 @@ fn get_random_brightness(random: &Random) -> f32 {
 }
 
 async fn poll_sensor(random: Random) {
-    let poll_rate = Duration::from_millis(random.config.strobe_interval.unwrap_or(1000).clamp(20, 10000));
+    let poll_rate = Duration::from_millis(
+        random
+            .config
+            .strobe_interval
+            .unwrap_or(1000)
+            .clamp(20, 10000),
+    );
     let mut interval = time::interval(poll_rate);
 
     loop {


### PR DESCRIPTION
feat: adds more configuration possibilies for the `random` integratio)n: `min/max_brightness`, `min/max_saturation`, `transition` and `strobe_interval`.

fix: stops the existing interval tick before a new one is started in case the random integration settings are changed when homectl-server is running.