### PR TITLE
Add state logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1532,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1750,7 @@ dependencies = [
  "eyre",
  "futures",
  "futures-util",
+ "globset",
  "ical",
  "itertools 0.14.0",
  "jsonptr",

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN corepack enable
 
 WORKDIR /app/ui
 
-COPY ui/package.json ui/pnpm-lock.yaml ./
+COPY ui/package.json ui/pnpm-lock.yaml ui/pnpm-workspace.yaml ./
+RUN corepack prepare pnpm@11.5.0 --activate
 RUN pnpm install --frozen-lockfile
 
 COPY ui ./

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.9.5"
 authors = ["Rasmus Lövegren <fruitiex@gmail.com>"]
 edition = "2021"
 default-run = "homectl-server"
+build = "build.rs"
 
 [lib]
 name = "homectl_server"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -77,6 +77,7 @@ clap = { version = "=4.5.48", features = ["derive", "env"] }
 boa_engine = "=0.20.0"
 percent-encoding = "=2.3.2"
 regex = "=1.11.1"
+globset = "=0.4.15"
 reqwest = { version = "=0.12.23", default-features = false, features = ["json", "rustls-tls"] }
 ical = { version = "=0.11.0", features = ["ical"] }
 csv = "=1.3.1"

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let manifest = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let prod = Path::new(&manifest)
+        .parent()
+        .unwrap()
+        .join("prod-config.toml");
+    // Tell the compiler to allow `cfg(has_prod_config)` checks and, if the
+    // file exists, enable the `has_prod_config` cfg so tests can be
+    // conditionally compiled.
+    println!("cargo:rustc-check-cfg=cfg(has_prod_config)");
+    if prod.exists() {
+        println!("cargo:rustc-cfg=has_prod_config");
+    } else {
+        println!("cargo:warning=prod-config.toml not found; prod-config tests will be ignored at compile time");
+    }
+}

--- a/server/build.rs
+++ b/server/build.rs
@@ -11,9 +11,12 @@ fn main() {
     // file exists, enable the `has_prod_config` cfg so tests can be
     // conditionally compiled.
     println!("cargo:rustc-check-cfg=cfg(has_prod_config)");
+    // Only emit the missing-file warning when running `cargo test`.
+    // Cargo sets `PROFILE=test` for test builds.
+    let profile = env::var("PROFILE").unwrap_or_default();
     if prod.exists() {
         println!("cargo:rustc-cfg=has_prod_config");
-    } else {
+    } else if profile == "test" {
         println!("cargo:warning=prod-config.toml not found; prod-config tests will be ignored at compile time");
     }
 }

--- a/server/src/api/config.rs
+++ b/server/src/api/config.rs
@@ -42,6 +42,7 @@ use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use warp::{http::StatusCode, Filter, Reply};
 
+use crate::core::integrations::PLUGIN_MQTT;
 use crate::core::snapshot::SnapshotHandle;
 
 use super::{
@@ -3791,7 +3792,7 @@ fn derive_migrated_mqtt_sensor_devices(config: &ConfigExport) -> Vec<Device> {
     let mqtt_integration_ids = config
         .integrations
         .iter()
-        .filter(|integration| integration.plugin == "mqtt")
+        .filter(|integration| integration.plugin == PLUGIN_MQTT)
         .map(|integration| IntegrationId::from(integration.id.clone()))
         .collect::<HashSet<_>>();
 
@@ -3959,6 +3960,7 @@ async fn migrate_apply(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::integrations::PLUGIN_DUMMY;
     use crate::types::device::DeviceId;
     use ordered_float::OrderedFloat;
 
@@ -3970,7 +3972,7 @@ mod tests {
             "integrations": [
                 {
                     "id": "dummy",
-                    "plugin": "dummy",
+                    "plugin": PLUGIN_DUMMY,
                     "config": { "devices": {} },
                     "enabled": true
                 }
@@ -4047,7 +4049,7 @@ devices = [
         let preview = MigratePreviewResult {
             integrations: vec![IntegrationRow {
                 id: "zigbee2mqtt".to_string(),
-                plugin: "mqtt".to_string(),
+                plugin: PLUGIN_MQTT.to_string(),
                 config: serde_json::json!({}),
                 enabled: true,
             }],
@@ -4128,7 +4130,7 @@ devices = [
         let preview = MigratePreviewResult {
             integrations: vec![IntegrationRow {
                 id: "zigbee2mqtt".to_string(),
-                plugin: "mqtt".to_string(),
+                plugin: PLUGIN_MQTT.to_string(),
                 config: serde_json::json!({}),
                 enabled: true,
             }],
@@ -4197,7 +4199,7 @@ devices = [
         let preview = MigratePreviewResult {
             integrations: vec![IntegrationRow {
                 id: "zigbee2mqtt".to_string(),
-                plugin: "mqtt".to_string(),
+                plugin: PLUGIN_MQTT.to_string(),
                 config: serde_json::json!({}),
                 enabled: true,
             }],
@@ -4276,7 +4278,7 @@ devices = [
             },
             integrations: vec![IntegrationRow {
                 id: "zigbee2mqtt".to_string(),
-                plugin: "mqtt".to_string(),
+                plugin: PLUGIN_MQTT.to_string(),
                 config: serde_json::json!({ "host": "broker" }),
                 enabled: true,
             }],
@@ -4336,7 +4338,7 @@ devices = [
         let preview = MigratePreviewResult {
             integrations: vec![IntegrationRow {
                 id: "zigbee2mqtt".to_string(),
-                plugin: "mqtt".to_string(),
+                plugin: PLUGIN_MQTT.to_string(),
                 config: serde_json::json!({}),
                 enabled: true,
             }],
@@ -4371,7 +4373,7 @@ devices = [
         let preview = MigratePreviewResult {
             integrations: vec![IntegrationRow {
                 id: "zigbee2mqtt".to_string(),
-                plugin: "mqtt".to_string(),
+                plugin: PLUGIN_MQTT.to_string(),
                 config: serde_json::json!({}),
                 enabled: true,
             }],

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -181,21 +181,23 @@ fn ui_config_route(snapshot: SnapshotHandle) -> BoxedFilter<(Response,)> {
         .and(warp::get())
         .and(warp::header::optional::<String>("host"))
         .and(warp::header::optional::<String>("x-forwarded-proto"))
-        .and_then(move |host: Option<String>, forwarded_proto: Option<String>| {
-            let snapshot = snapshot.clone();
-            async move {
-                let widget_settings = snapshot.load().runtime_config.widget_settings.clone();
+        .and_then(
+            move |host: Option<String>, forwarded_proto: Option<String>| {
+                let snapshot = snapshot.clone();
+                async move {
+                    let widget_settings = snapshot.load().runtime_config.widget_settings.clone();
 
-                Ok::<_, warp::Rejection>(
-                    warp::reply::json(&UiConfigResponse::from_request(
-                        host.as_deref(),
-                        forwarded_proto.as_deref(),
-                        &widget_settings,
-                    ))
-                    .into_response(),
-                )
-            }
-        })
+                    Ok::<_, warp::Rejection>(
+                        warp::reply::json(&UiConfigResponse::from_request(
+                            host.as_deref(),
+                            forwarded_proto.as_deref(),
+                            &widget_settings,
+                        ))
+                        .into_response(),
+                    )
+                }
+            },
+        )
         .boxed()
 }
 

--- a/server/src/api/widgets/calendar.rs
+++ b/server/src/api/widgets/calendar.rs
@@ -109,7 +109,7 @@ fn parse_events(ics: &str) -> Result<Value, String> {
         }
     }
 
-    events.sort_by(|a, b| a.start.cmp(&b.start));
+    events.sort_by_key(|a| a.start);
     events.truncate(10);
 
     let events: Vec<Value> = events

--- a/server/src/api/widgets/influx.rs
+++ b/server/src/api/widgets/influx.rs
@@ -14,10 +14,7 @@ pub async fn query(
     token: &str,
     flux: &str,
 ) -> Result<Vec<Value>, String> {
-    let endpoint = format!(
-        "{}/api/v2/query?org=influxdata",
-        url.trim_end_matches('/')
-    );
+    let endpoint = format!("{}/api/v2/query?org=influxdata", url.trim_end_matches('/'));
     let res = http
         .post(endpoint)
         .header("Authorization", format!("Token {token}"))
@@ -74,7 +71,10 @@ fn parse_annotated_csv(body: &str) -> Result<Vec<Value>, String> {
                 continue;
             }
             let raw = values.get(idx).map(String::as_str).unwrap_or("");
-            let dtype = datatypes.get(idx + 1).map(String::as_str).unwrap_or("string");
+            let dtype = datatypes
+                .get(idx + 1)
+                .map(String::as_str)
+                .unwrap_or("string");
             obj.insert(header.clone(), coerce(raw, dtype));
         }
         rows.push(Value::Object(obj));

--- a/server/src/api/widgets/spot_prices.rs
+++ b/server/src/api/widgets/spot_prices.rs
@@ -8,9 +8,7 @@ use warp::{
     Filter, Reply,
 };
 
-use super::{
-    influx, widget_setting_string_or_env, INFLUXDB_SETTING_KEY, TOKEN_FIELD, URL_FIELD,
-};
+use super::{influx, widget_setting_string_or_env, INFLUXDB_SETTING_KEY, TOKEN_FIELD, URL_FIELD};
 
 const QUERY: &str = r#"
           import "date"
@@ -23,10 +21,7 @@ const QUERY: &str = r#"
             |> filter(fn: (r) => r["_measurement"] == "price")
         "#;
 
-pub fn route(
-    snapshot: SnapshotHandle,
-    http: reqwest::Client,
-) -> BoxedFilter<(Response,)> {
+pub fn route(snapshot: SnapshotHandle, http: reqwest::Client) -> BoxedFilter<(Response,)> {
     warp::path!("api" / "influxdb" / "spot-prices")
         .and(warp::get())
         .and_then(move || {

--- a/server/src/api/ws.rs
+++ b/server/src/api/ws.rs
@@ -42,9 +42,7 @@ pub fn ws(
              ws_handle: WebSockets,
              event_tx: TxEventChannel| {
                 // This will call our function if the handshake succeeds.
-                ws.on_upgrade(move |socket| {
-                    user_connected(socket, snapshot, ws_handle, event_tx)
-                })
+                ws.on_upgrade(move |socket| user_connected(socket, snapshot, ws_handle, event_tx))
             },
         )
 }

--- a/server/src/core/devices.rs
+++ b/server/src/core/devices.rs
@@ -830,6 +830,7 @@ mod tests {
         build_spatial_rollout_plan, sort_devices_by_spatial_rollout_source, SpatialRolloutPlan,
     };
     use super::{ActivateSceneRequest, Devices};
+    use crate::core::integrations::{PLUGIN_CIRCADIAN, PLUGIN_DUMMY, PLUGIN_MQTT};
     use crate::core::{groups::Groups, scenes::Scenes};
     use crate::db::config_queries::DevicePositionRow;
     use crate::types::color::Capabilities;
@@ -848,7 +849,10 @@ mod tests {
     use std::{collections::BTreeMap, str::FromStr};
 
     fn device_key(id: &str) -> DeviceKey {
-        DeviceKey::new(IntegrationId::from("dummy".to_string()), DeviceId::new(id))
+        DeviceKey::new(
+            IntegrationId::from(PLUGIN_DUMMY.to_string()),
+            DeviceId::new(id),
+        )
     }
 
     fn test_cli() -> Cli {
@@ -883,7 +887,7 @@ mod tests {
 
     fn managed_controllable_device(id: &str, name: &str) -> Device {
         Device::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new(id),
             name.to_string(),
             DeviceData::Controllable(ControllableDevice::new(
@@ -901,7 +905,7 @@ mod tests {
 
     fn placeholder_sensor(id: &str, name: &str, raw: Option<serde_json::Value>) -> Device {
         Device::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new(id),
             name.to_string(),
             DeviceData::Sensor(SensorDevice::unknown_placeholder()),
@@ -911,7 +915,7 @@ mod tests {
 
     fn boolean_sensor(id: &str, name: &str, value: bool, raw: Option<serde_json::Value>) -> Device {
         Device::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new(id),
             name.to_string(),
             DeviceData::Sensor(SensorDevice::Boolean { value }),
@@ -921,7 +925,7 @@ mod tests {
 
     fn controllable_device(id: &str, name: &str, raw: Option<serde_json::Value>) -> Device {
         Device::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new(id),
             name.to_string(),
             DeviceData::Controllable(ControllableDevice::new(
@@ -1030,7 +1034,7 @@ mod tests {
     #[test]
     fn spatial_invalidation_order_prefers_nearest_positioned_targets() {
         let source = DeviceKey::new(
-            IntegrationId::from("circadian".to_string()),
+            IntegrationId::from(PLUGIN_CIRCADIAN.to_string()),
             DeviceId::new("color"),
         );
         let near = managed_controllable_device("near", "Near");

--- a/server/src/core/event.rs
+++ b/server/src/core/event.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use color_eyre::Result;
 
 use crate::db::actions::{db_store_scene_overrides, db_store_ui_state};
+use crate::db::config_queries;
 use crate::types::{
     action::Action,
     device::{Device, DeviceKey, DevicesState},
@@ -17,8 +18,6 @@ use crate::types::{
     },
     ui::UiActionDescriptor,
 };
-
-use crate::db::config_queries;
 
 use super::devices::ActivateSceneRequest;
 use super::snapshot::SnapshotChanges;
@@ -559,6 +558,7 @@ pub async fn handle_event(state: &mut AppState, event: &Event) -> Result<EventOu
 #[cfg(test)]
 mod tests {
     use super::{handle_event, DeferredEventWork};
+    use crate::core::integrations::PLUGIN_MQTT;
     use crate::core::{
         devices::Devices,
         groups::Groups,
@@ -696,7 +696,7 @@ mod tests {
     async fn set_external_state_is_deferred() {
         let (mut state, _event_rx) = test_state();
         let device = Device::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new("lamp1"),
             "Lamp 1".to_string(),
             DeviceData::Controllable(ControllableDevice::new(

--- a/server/src/core/integrations/actor.rs
+++ b/server/src/core/integrations/actor.rs
@@ -30,6 +30,7 @@ use crate::types::{
 
 const LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const DATA_PLANE_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const INTEGRATION_MAILBOX_CAPACITY: usize = 32;
 
 /// Cheaply cloneable handle for talking to a per-integration actor. The
 /// `module_name` and `config` fields mirror what `LoadedIntegration`
@@ -37,7 +38,8 @@ const DATA_PLANE_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 /// current state without consulting the actor.
 #[derive(Clone)]
 pub struct IntegrationHandle {
-    tx: mpsc::UnboundedSender<IntegrationCmd>,
+    tx: mpsc::Sender<IntegrationCmd>,
+    wants_runtime_state_changes: bool,
     pub module_name: String,
     pub config: serde_json::Value,
 }
@@ -50,7 +52,8 @@ impl IntegrationHandle {
         config: serde_json::Value,
         device_update_policy: OutboundDeviceUpdatePolicy,
     ) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel::<IntegrationCmd>();
+        let wants_runtime_state_changes = integration.wants_runtime_state_changes();
+        let (tx, rx) = mpsc::channel::<IntegrationCmd>(INTEGRATION_MAILBOX_CAPACITY);
         tokio::spawn(run_integration_actor(
             integration_id,
             integration,
@@ -59,9 +62,14 @@ impl IntegrationHandle {
         ));
         IntegrationHandle {
             tx,
+            wants_runtime_state_changes,
             module_name,
             config,
         }
+    }
+
+    pub fn wants_runtime_state_changes(&self) -> bool {
+        self.wants_runtime_state_changes
     }
 
     pub async fn register(&self) -> Result<()> {
@@ -84,6 +92,7 @@ impl IntegrationHandle {
         let (done_tx, done_rx) = oneshot::channel();
         self.tx
             .send(make_cmd(done_tx))
+            .await
             .map_err(|_| eyre!("Integration actor channel closed"))?;
         done_rx
             .await
@@ -93,18 +102,22 @@ impl IntegrationHandle {
     pub fn set_device_state(&self, device: Device) {
         if self
             .tx
-            .send(IntegrationCmd::SetDeviceState {
+            .try_send(IntegrationCmd::SetDeviceState {
                 device: Box::new(device),
             })
             .is_err()
         {
-            warn!("Integration actor channel closed; dropping SetDeviceState");
+            warn!("Integration actor channel closed or full; dropping SetDeviceState");
         }
     }
 
     pub fn run_action(&self, payload: IntegrationActionPayload) {
-        if self.tx.send(IntegrationCmd::RunAction { payload }).is_err() {
-            warn!("Integration actor channel closed; dropping RunAction");
+        if self
+            .tx
+            .try_send(IntegrationCmd::RunAction { payload })
+            .is_err()
+        {
+            warn!("Integration actor channel closed or full; dropping RunAction");
         }
     }
 
@@ -116,14 +129,14 @@ impl IntegrationHandle {
     ) {
         if self
             .tx
-            .send(IntegrationCmd::RuntimeStateChanged {
+            .try_send(IntegrationCmd::RuntimeStateChanged {
                 previous: Box::new(previous),
                 current: Box::new(current),
                 changes,
             })
             .is_err()
         {
-            warn!("Integration actor channel closed; dropping RuntimeStateChanged");
+            warn!("Integration actor channel closed or full; dropping RuntimeStateChanged");
         }
     }
 }
@@ -132,7 +145,7 @@ async fn run_integration_actor(
     integration_id: IntegrationId,
     mut integration: Box<dyn Integration>,
     device_update_policy: OutboundDeviceUpdatePolicy,
-    mut rx: mpsc::UnboundedReceiver<IntegrationCmd>,
+    mut rx: mpsc::Receiver<IntegrationCmd>,
 ) {
     let mut device_updates = DeviceUpdateQueue::new(device_update_policy);
     let mut registered = false;

--- a/server/src/core/integrations/actor.rs
+++ b/server/src/core/integrations/actor.rs
@@ -311,6 +311,9 @@ async fn handle_integration_command(
             }
 
             let result = run_lifecycle_command(integration_id, "stop", integration.stop()).await;
+            if result.is_ok() {
+                *registered = false;
+            }
             let _ = done.send(result);
         }
         IntegrationCmd::SetDeviceState { device } => {

--- a/server/src/core/integrations/actor.rs
+++ b/server/src/core/integrations/actor.rs
@@ -10,7 +10,10 @@
 use std::{
     collections::{HashMap, VecDeque},
     future::Future,
-    sync::{Arc, atomic::{AtomicUsize, Ordering}},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -185,7 +188,6 @@ impl IntegrationHandle {
         }
     }
 }
-
 
 async fn run_integration_actor(
     integration_id: IntegrationId,

--- a/server/src/core/integrations/actor.rs
+++ b/server/src/core/integrations/actor.rs
@@ -403,6 +403,7 @@ async fn run_data_plane_command<F>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::integrations::PLUGIN_MQTT;
     use crate::types::{
         color::Capabilities,
         device::{ControllableDevice, DeviceData, DeviceId, ManageKind},
@@ -416,7 +417,7 @@ mod tests {
         Device {
             id: DeviceId::new(device_id),
             name: device_id.to_string(),
-            integration_id: IntegrationId::from("mqtt".to_string()),
+            integration_id: IntegrationId::from(PLUGIN_MQTT.to_string()),
             data: DeviceData::Controllable(ControllableDevice::new(
                 None,
                 power,

--- a/server/src/core/integrations/actor.rs
+++ b/server/src/core/integrations/actor.rs
@@ -10,6 +10,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     future::Future,
+    sync::{Arc, atomic::{AtomicUsize, Ordering}},
     time::Duration,
 };
 
@@ -30,7 +31,7 @@ use crate::types::{
 
 const LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const DATA_PLANE_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
-const INTEGRATION_MAILBOX_CAPACITY: usize = 32;
+const INTEGRATION_QUEUE_WARNING_LIMIT: usize = 64;
 
 /// Cheaply cloneable handle for talking to a per-integration actor. The
 /// `module_name` and `config` fields mirror what `LoadedIntegration`
@@ -38,7 +39,8 @@ const INTEGRATION_MAILBOX_CAPACITY: usize = 32;
 /// current state without consulting the actor.
 #[derive(Clone)]
 pub struct IntegrationHandle {
-    tx: mpsc::Sender<IntegrationCmd>,
+    tx: mpsc::UnboundedSender<IntegrationCmd>,
+    pending: Arc<AtomicUsize>,
     wants_runtime_state_changes: bool,
     pub module_name: String,
     pub config: serde_json::Value,
@@ -53,15 +55,18 @@ impl IntegrationHandle {
         device_update_policy: OutboundDeviceUpdatePolicy,
     ) -> Self {
         let wants_runtime_state_changes = integration.wants_runtime_state_changes();
-        let (tx, rx) = mpsc::channel::<IntegrationCmd>(INTEGRATION_MAILBOX_CAPACITY);
+        let pending = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = mpsc::unbounded_channel::<IntegrationCmd>();
         tokio::spawn(run_integration_actor(
             integration_id,
             integration,
             device_update_policy,
             rx,
+            pending.clone(),
         ));
         IntegrationHandle {
             tx,
+            pending,
             wants_runtime_state_changes,
             module_name,
             config,
@@ -90,34 +95,63 @@ impl IntegrationHandle {
         F: FnOnce(oneshot::Sender<Result<()>>) -> IntegrationCmd,
     {
         let (done_tx, done_rx) = oneshot::channel();
-        self.tx
-            .send(make_cmd(done_tx))
+        self.pending.fetch_add(1, Ordering::SeqCst);
+        if self.tx.send(make_cmd(done_tx)).is_err() {
+            self.pending.fetch_sub(1, Ordering::SeqCst);
+            return Err(eyre!("Integration actor channel closed"));
+        }
+
+        let curr = self.pending.load(Ordering::SeqCst);
+        if curr >= INTEGRATION_QUEUE_WARNING_LIMIT {
+            warn!(
+                "Integration actor queue for {} has {curr} messages",
+                self.module_name
+            );
+        }
+
+        let result = done_rx
             .await
-            .map_err(|_| eyre!("Integration actor channel closed"))?;
-        done_rx
-            .await
-            .map_err(|_| eyre!("Integration actor dropped lifecycle command"))?
+            .map_err(|_| eyre!("Integration actor dropped lifecycle command"))?;
+        result
     }
 
     pub fn set_device_state(&self, device: Device) {
+        self.pending.fetch_add(1, Ordering::SeqCst);
         if self
             .tx
-            .try_send(IntegrationCmd::SetDeviceState {
+            .send(IntegrationCmd::SetDeviceState {
                 device: Box::new(device),
             })
             .is_err()
         {
-            warn!("Integration actor channel closed or full; dropping SetDeviceState");
+            self.pending.fetch_sub(1, Ordering::SeqCst);
+            warn!("Integration actor channel closed; dropping SetDeviceState");
+            return;
+        }
+
+        let curr = self.pending.load(Ordering::SeqCst);
+        if curr >= INTEGRATION_QUEUE_WARNING_LIMIT {
+            warn!(
+                "Integration actor queue for {} has {curr} messages",
+                self.module_name
+            );
         }
     }
 
     pub fn run_action(&self, payload: IntegrationActionPayload) {
-        if self
-            .tx
-            .try_send(IntegrationCmd::RunAction { payload })
-            .is_err()
-        {
-            warn!("Integration actor channel closed or full; dropping RunAction");
+        self.pending.fetch_add(1, Ordering::SeqCst);
+        if self.tx.send(IntegrationCmd::RunAction { payload }).is_err() {
+            self.pending.fetch_sub(1, Ordering::SeqCst);
+            warn!("Integration actor channel closed; dropping RunAction");
+            return;
+        }
+
+        let curr = self.pending.load(Ordering::SeqCst);
+        if curr >= INTEGRATION_QUEUE_WARNING_LIMIT {
+            warn!(
+                "Integration actor queue for {} has {curr} messages",
+                self.module_name
+            );
         }
     }
 
@@ -127,25 +161,38 @@ impl IntegrationHandle {
         current: RuntimeSnapshot,
         changes: SnapshotChanges,
     ) {
+        self.pending.fetch_add(1, Ordering::SeqCst);
         if self
             .tx
-            .try_send(IntegrationCmd::RuntimeStateChanged {
+            .send(IntegrationCmd::RuntimeStateChanged {
                 previous: Box::new(previous),
                 current: Box::new(current),
                 changes,
             })
             .is_err()
         {
-            warn!("Integration actor channel closed or full; dropping RuntimeStateChanged");
+            self.pending.fetch_sub(1, Ordering::SeqCst);
+            warn!("Integration actor channel closed; dropping RuntimeStateChanged");
+            return;
+        }
+
+        let curr = self.pending.load(Ordering::SeqCst);
+        if curr >= INTEGRATION_QUEUE_WARNING_LIMIT {
+            warn!(
+                "Integration actor queue for {} has {curr} messages",
+                self.module_name
+            );
         }
     }
 }
+
 
 async fn run_integration_actor(
     integration_id: IntegrationId,
     mut integration: Box<dyn Integration>,
     device_update_policy: OutboundDeviceUpdatePolicy,
-    mut rx: mpsc::Receiver<IntegrationCmd>,
+    mut rx: mpsc::UnboundedReceiver<IntegrationCmd>,
+    pending: Arc<AtomicUsize>,
 ) {
     let mut device_updates = DeviceUpdateQueue::new(device_update_policy);
     let mut registered = false;
@@ -186,6 +233,10 @@ async fn run_integration_actor(
             }
             break;
         };
+
+        // decrement the outstanding counter for this message now that
+        // we've received it from the queue
+        pending.fetch_sub(1, Ordering::SeqCst);
 
         handle_integration_command(
             &integration_id,

--- a/server/src/core/integrations/actor.rs
+++ b/server/src/core/integrations/actor.rs
@@ -20,6 +20,7 @@ use tokio::{
 };
 
 use super::command::IntegrationCmd;
+use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::types::{
     device::{Device, DeviceKey},
     integration::{
@@ -106,6 +107,25 @@ impl IntegrationHandle {
             warn!("Integration actor channel closed; dropping RunAction");
         }
     }
+
+    pub fn runtime_state_changed(
+        &self,
+        previous: RuntimeSnapshot,
+        current: RuntimeSnapshot,
+        changes: SnapshotChanges,
+    ) {
+        if self
+            .tx
+            .send(IntegrationCmd::RuntimeStateChanged {
+                previous: Box::new(previous),
+                current: Box::new(current),
+                changes,
+            })
+            .is_err()
+        {
+            warn!("Integration actor channel closed; dropping RuntimeStateChanged");
+        }
+    }
 }
 
 async fn run_integration_actor(
@@ -115,6 +135,7 @@ async fn run_integration_actor(
     mut rx: mpsc::UnboundedReceiver<IntegrationCmd>,
 ) {
     let mut device_updates = DeviceUpdateQueue::new(device_update_policy);
+    let mut registered = false;
     if let Some(min_interval) = device_updates.policy.min_interval() {
         info!(
             "Integration {integration_id} outbound device updates rate-limited to at most one every {:?}",
@@ -153,8 +174,14 @@ async fn run_integration_actor(
             break;
         };
 
-        handle_integration_command(&integration_id, &mut integration, &mut device_updates, cmd)
-            .await;
+        handle_integration_command(
+            &integration_id,
+            &mut integration,
+            &mut device_updates,
+            &mut registered,
+            cmd,
+        )
+        .await;
     }
 
     debug!("Integration actor for {integration_id} exiting (channel closed)");
@@ -259,12 +286,16 @@ async fn handle_integration_command(
     integration_id: &IntegrationId,
     integration: &mut Box<dyn Integration>,
     device_updates: &mut DeviceUpdateQueue,
+    registered: &mut bool,
     cmd: IntegrationCmd,
 ) {
     match cmd {
         IntegrationCmd::Register { done } => {
             let result =
                 run_lifecycle_command(integration_id, "register", integration.register()).await;
+            if result.is_ok() {
+                *registered = true;
+            }
             let _ = done.send(result);
         }
         IntegrationCmd::Start { done } => {
@@ -292,6 +323,25 @@ async fn handle_integration_command(
                 integration_id,
                 "run_integration_action",
                 integration.run_integration_action(&payload),
+            )
+            .await;
+        }
+        IntegrationCmd::RuntimeStateChanged {
+            previous,
+            current,
+            changes,
+        } => {
+            if !*registered {
+                debug!(
+                    "Ignoring runtime-state change for {integration_id} until register completes",
+                );
+                return;
+            }
+
+            run_data_plane_command(
+                integration_id,
+                "on_runtime_state_change",
+                integration.on_runtime_state_change(&previous, &current, changes),
             )
             .await;
         }

--- a/server/src/core/integrations/command.rs
+++ b/server/src/core/integrations/command.rs
@@ -13,11 +13,21 @@ use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::types::{device::Device, integration::IntegrationActionPayload};
 
 pub enum IntegrationCmd {
-    Register { done: oneshot::Sender<Result<()>> },
-    Start { done: oneshot::Sender<Result<()>> },
-    Stop { done: oneshot::Sender<Result<()>> },
-    SetDeviceState { device: Box<Device> },
-    RunAction { payload: IntegrationActionPayload },
+    Register {
+        done: oneshot::Sender<Result<()>>,
+    },
+    Start {
+        done: oneshot::Sender<Result<()>>,
+    },
+    Stop {
+        done: oneshot::Sender<Result<()>>,
+    },
+    SetDeviceState {
+        device: Box<Device>,
+    },
+    RunAction {
+        payload: IntegrationActionPayload,
+    },
     RuntimeStateChanged {
         previous: Box<RuntimeSnapshot>,
         current: Box<RuntimeSnapshot>,

--- a/server/src/core/integrations/command.rs
+++ b/server/src/core/integrations/command.rs
@@ -9,6 +9,7 @@
 use color_eyre::Result;
 use tokio::sync::oneshot;
 
+use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::types::{device::Device, integration::IntegrationActionPayload};
 
 pub enum IntegrationCmd {
@@ -17,4 +18,9 @@ pub enum IntegrationCmd {
     Stop { done: oneshot::Sender<Result<()>> },
     SetDeviceState { device: Box<Device> },
     RunAction { payload: IntegrationActionPayload },
+    RuntimeStateChanged {
+        previous: Box<RuntimeSnapshot>,
+        current: Box<RuntimeSnapshot>,
+        changes: SnapshotChanges,
+    },
 }

--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -6,7 +6,8 @@ pub use actor::IntegrationHandle;
 use crate::db::config_queries;
 use crate::integrations::cron::Cron;
 use crate::integrations::{
-    circadian::Circadian, dummy::Dummy, mqtt::Mqtt, random::Random, timer::Timer,
+    circadian::Circadian, dummy::Dummy, mqtt::Mqtt, random::Random, state_logger::StateLogger,
+    timer::Timer,
 };
 use crate::types::{
     device::Device,
@@ -17,6 +18,7 @@ use crate::types::{
         IntegrationId, OutboundDeviceUpdatePolicy,
     },
 };
+use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::utils::cli::Cli;
 use color_eyre::Result;
 use eyre::eyre;
@@ -25,7 +27,15 @@ use std::collections::HashMap;
 
 pub type CustomIntegrationsMap = HashMap<IntegrationId, IntegrationHandle>;
 
-const BUILT_IN_PLUGIN_NAMES: [&str; 6] = ["mqtt", "circadian", "cron", "timer", "dummy", "random"];
+const BUILT_IN_PLUGIN_NAMES: [&str; 7] = [
+    "mqtt",
+    "circadian",
+    "cron",
+    "timer",
+    "dummy",
+    "random",
+    "state_logger",
+];
 
 #[derive(Clone)]
 pub struct Integrations {
@@ -135,6 +145,17 @@ impl Integrations {
 
         handle.run_action(payload.clone());
         Ok(())
+    }
+
+    pub fn notify_runtime_state_changed(
+        &self,
+        previous: &RuntimeSnapshot,
+        current: &RuntimeSnapshot,
+        changes: SnapshotChanges,
+    ) {
+        for handle in self.custom_integrations.values() {
+            handle.runtime_state_changed(previous.clone(), current.clone(), changes);
+        }
     }
 
     pub async fn load_config_rows(
@@ -672,6 +693,65 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 ),
             ],
         )),
+        "state_logger" => Some(schema_without_outbound(
+            "state_logger",
+            "State Logger",
+            "Log selected device or sensor state changes from one integration.",
+            vec![
+                text_config_field(
+                    "source_integration_id",
+                    "Source integration ID",
+                    true,
+                    "Only log devices from this integration.",
+                    Some("mqtt"),
+                ),
+                text_config_field(
+                    "device_name_pattern",
+                    "Device name pattern",
+                    true,
+                    "Pattern used to match device names.",
+                    Some("Kitchen *"),
+                ),
+                select_config_field(
+                    "match_mode",
+                    "Pattern match mode",
+                    false,
+                    "How to interpret the device name pattern.",
+                    vec![
+                        option(
+                            "Glob",
+                            json!("glob"),
+                            Some("Supports `*` and `?` wildcards."),
+                        ),
+                        option(
+                            "Regex",
+                            json!("regex"),
+                            Some("Interpret the pattern as a regular expression."),
+                        ),
+                    ],
+                ),
+                with_help_text(
+                    text_config_field(
+                        "value_path",
+                        "Value path",
+                        true,
+                        "JSON pointer evaluated against the serialized device state.",
+                        Some("/value"),
+                    ),
+                    "JSON Pointer syntax. The path is evaluated against the serialized device state, so it should start with /. Use / between keys, for example /value, /state/power or /state/color/h.",
+                ),
+                with_help_text(
+                    text_config_field(
+                        "postgresql_url",
+                        "PostgreSQL URL",
+                        false,
+                        "Optional PostgreSQL connection string for state_logger.",
+                        Some("postgresql://user:password@host:5432/database"),
+                    ),
+                    "Leave this empty to reuse the app's DATABASE_URL connection. If set, state_logger writes to this database instead of the PostgreSQL connection used by HomeCTL. The schema used is `public` and the name of the database is `state_logger_events`.",
+                ),
+            ],
+        )),
         _ => None,
     }
 }
@@ -684,6 +764,20 @@ fn schema(
 ) -> IntegrationConfigSchema {
     fields.push(outbound_device_update_field());
 
+    IntegrationConfigSchema {
+        plugin: plugin.to_string(),
+        name: name.to_string(),
+        description: description.to_string(),
+        fields,
+    }
+}
+
+fn schema_without_outbound(
+    plugin: &str,
+    name: &str,
+    description: &str,
+    fields: Vec<IntegrationConfigFieldSchema>,
+) -> IntegrationConfigSchema {
     IntegrationConfigSchema {
         plugin: plugin.to_string(),
         name: name.to_string(),
@@ -901,6 +995,7 @@ fn load_custom_integration(
     match module_name {
         "circadian" => Ok(Box::new(Circadian::new(id, config, cli, event_tx)?)),
         "random" => Ok(Box::new(Random::new(id, config, cli, event_tx)?)),
+        "state_logger" => Ok(Box::new(StateLogger::new(id, config, cli, event_tx)?)),
         "dummy" => Ok(Box::new(Dummy::new(id, config, cli, event_tx)?)),
         "mqtt" => Ok(Box::new(Mqtt::new(id, config, cli, event_tx)?)),
         "timer" => Ok(Box::new(Timer::new(id, config, cli, event_tx)?)),
@@ -927,6 +1022,10 @@ mod tests {
     #[test]
     fn every_schema_includes_common_outbound_pacing_field() {
         for schema in integration_config_schemas() {
+            if schema.plugin == "state_logger" {
+                continue;
+            }
+
             assert!(
                 schema
                     .fields
@@ -985,6 +1084,41 @@ mod tests {
                 "strobe_interval",
                 "outbound_device_updates.min_interval_ms",
             ]
+        );
+    }
+
+    #[test]
+    fn state_logger_schema_exposes_logger_fields() {
+        let schema = integration_config_schema("state_logger")
+            .expect("state_logger schema should exist");
+        let keys = schema
+            .fields
+            .iter()
+            .map(|field| field.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            vec![
+                "source_integration_id",
+                "device_name_pattern",
+                "match_mode",
+                "postgresql_url",
+                "value_path",
+            ]
+        );
+    }
+
+    #[test]
+    fn state_logger_schema_does_not_include_outbound_pacing_field() {
+        let schema = integration_config_schema("state_logger")
+            .expect("state_logger schema should exist");
+
+        assert!(
+            schema
+                .fields
+                .iter()
+                .all(|field| field.key != "outbound_device_updates.min_interval_ms")
         );
     }
 }

--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -27,14 +27,22 @@ use std::collections::HashMap;
 
 pub type CustomIntegrationsMap = HashMap<IntegrationId, IntegrationHandle>;
 
+pub const PLUGIN_MQTT: &str = "mqtt";
+pub const PLUGIN_CIRCADIAN: &str = "circadian";
+pub const PLUGIN_CRON: &str = "cron";
+pub const PLUGIN_TIMER: &str = "timer";
+pub const PLUGIN_DUMMY: &str = "dummy";
+pub const PLUGIN_RANDOM: &str = "random";
+pub const PLUGIN_STATE_LOGGER: &str = "state_logger";
+
 const BUILT_IN_PLUGIN_NAMES: [&str; 7] = [
-    "mqtt",
-    "circadian",
-    "cron",
-    "timer",
-    "dummy",
-    "random",
-    "state_logger",
+    PLUGIN_MQTT,
+    PLUGIN_CIRCADIAN,
+    PLUGIN_CRON,
+    PLUGIN_TIMER,
+    PLUGIN_DUMMY,
+    PLUGIN_RANDOM,
+    PLUGIN_STATE_LOGGER,
 ];
 
 #[derive(Clone)]
@@ -301,8 +309,8 @@ pub fn integration_config_schemas() -> Vec<IntegrationConfigSchema> {
 
 fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
     match plugin {
-        "mqtt" => Some(schema(
-            "mqtt",
+        PLUGIN_MQTT => Some(schema(
+            PLUGIN_MQTT,
             "MQTT",
             "Connect devices through MQTT topics, including Zigbee2MQTT-style bridges.",
             vec![
@@ -499,8 +507,8 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 ),
             ],
         )),
-        "circadian" => Some(schema(
-            "circadian",
+        PLUGIN_CIRCADIAN => Some(schema(
+            PLUGIN_CIRCADIAN,
             "Circadian",
             "Expose a virtual color sensor that follows a day/night color schedule.",
             vec![
@@ -573,8 +581,8 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 ),
             ],
         )),
-        "cron" => Some(schema(
-            "cron",
+        PLUGIN_CRON => Some(schema(
+            PLUGIN_CRON,
             "Cron",
             "Expose schedule devices that trigger actions from cron expressions.",
             vec![with_help_text(
@@ -595,8 +603,8 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 "Cron syntax is `second minute hour day-of-month month day-of-week`. Keep ids stable because routines and actions may reference the generated schedule devices.",
             )],
         )),
-        "timer" => Some(schema(
-            "timer",
+        PLUGIN_TIMER => Some(schema(
+            PLUGIN_TIMER,
             "Timer",
             "Expose a virtual timer sensor that can be started by integration actions.",
             vec![text_config_field(
@@ -607,8 +615,8 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 Some("Timer"),
             )],
         )),
-        "dummy" => Some(schema(
-            "dummy",
+        PLUGIN_DUMMY => Some(schema(
+            PLUGIN_DUMMY,
             "Dummy",
             "Create in-memory devices for development and testing without physical hardware.",
             vec![with_help_text(
@@ -631,8 +639,8 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 "Use dummy devices to prototype groups, scenes, and routines before connecting real hardware. Device ids become `integration_id/device_id` keys.",
             )],
         )),
-        "random" => Some(schema(
-            "random",
+        PLUGIN_RANDOM => Some(schema(
+            PLUGIN_RANDOM,
             "Random",
             "Expose a virtual color sensor that emits a random color every second.",
             vec![
@@ -693,8 +701,8 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 ),
             ],
         )),
-        "state_logger" => Some(schema_without_outbound(
-            "state_logger",
+        PLUGIN_STATE_LOGGER => Some(schema_without_outbound(
+            PLUGIN_STATE_LOGGER,
             "State Logger",
             "Log selected device or sensor state changes from one integration.",
             vec![
@@ -703,7 +711,7 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                     "Source integration ID",
                     true,
                     "Only log devices from this integration.",
-                    Some("mqtt"),
+                    Some(PLUGIN_MQTT),
                 ),
                 text_config_field(
                     "device_name_pattern",
@@ -993,13 +1001,13 @@ fn load_custom_integration(
     event_tx: TxEventChannel,
 ) -> Result<Box<dyn Integration>> {
     match module_name {
-        "circadian" => Ok(Box::new(Circadian::new(id, config, cli, event_tx)?)),
-        "random" => Ok(Box::new(Random::new(id, config, cli, event_tx)?)),
-        "state_logger" => Ok(Box::new(StateLogger::new(id, config, cli, event_tx)?)),
-        "dummy" => Ok(Box::new(Dummy::new(id, config, cli, event_tx)?)),
-        "mqtt" => Ok(Box::new(Mqtt::new(id, config, cli, event_tx)?)),
-        "timer" => Ok(Box::new(Timer::new(id, config, cli, event_tx)?)),
-        "cron" => Ok(Box::new(Cron::new(id, config, cli, event_tx)?)),
+        PLUGIN_CIRCADIAN => Ok(Box::new(Circadian::new(id, config, cli, event_tx)?)),
+        PLUGIN_RANDOM => Ok(Box::new(Random::new(id, config, cli, event_tx)?)),
+        PLUGIN_STATE_LOGGER => Ok(Box::new(StateLogger::new(id, config, cli, event_tx)?)),
+        PLUGIN_DUMMY => Ok(Box::new(Dummy::new(id, config, cli, event_tx)?)),
+        PLUGIN_MQTT => Ok(Box::new(Mqtt::new(id, config, cli, event_tx)?)),
+        PLUGIN_TIMER => Ok(Box::new(Timer::new(id, config, cli, event_tx)?)),
+        PLUGIN_CRON => Ok(Box::new(Cron::new(id, config, cli, event_tx)?)),
         _ => Err(eyre!("Unknown module name: {module_name}")),
     }
 }
@@ -1022,7 +1030,7 @@ mod tests {
     #[test]
     fn every_schema_includes_common_outbound_pacing_field() {
         for schema in integration_config_schemas() {
-            if schema.plugin == "state_logger" {
+            if schema.plugin == PLUGIN_STATE_LOGGER {
                 continue;
             }
 
@@ -1039,7 +1047,7 @@ mod tests {
 
     #[test]
     fn mqtt_schema_exposes_core_required_fields() {
-        let schema = integration_config_schema("mqtt").expect("mqtt schema should exist");
+        let schema = integration_config_schema(PLUGIN_MQTT).expect("mqtt schema should exist");
         let required_fields = schema
             .fields
             .iter()
@@ -1052,7 +1060,8 @@ mod tests {
 
     #[test]
     fn circadian_schema_uses_color_fields() {
-        let schema = integration_config_schema("circadian").expect("circadian schema should exist");
+        let schema =
+            integration_config_schema(PLUGIN_CIRCADIAN).expect("circadian schema should exist");
         let color_fields = schema
             .fields
             .iter()
@@ -1065,7 +1074,7 @@ mod tests {
 
     #[test]
     fn random_schema_exposes_random_config_fields() {
-        let schema = integration_config_schema("random").expect("random schema should exist");
+        let schema = integration_config_schema(PLUGIN_RANDOM).expect("random schema should exist");
         let keys = schema
             .fields
             .iter()
@@ -1089,8 +1098,8 @@ mod tests {
 
     #[test]
     fn state_logger_schema_exposes_logger_fields() {
-        let schema =
-            integration_config_schema("state_logger").expect("state_logger schema should exist");
+        let schema = integration_config_schema(PLUGIN_STATE_LOGGER)
+            .expect("state_logger schema should exist");
         let keys = schema
             .fields
             .iter()
@@ -1111,8 +1120,8 @@ mod tests {
 
     #[test]
     fn state_logger_schema_does_not_include_outbound_pacing_field() {
-        let schema =
-            integration_config_schema("state_logger").expect("state_logger schema should exist");
+        let schema = integration_config_schema(PLUGIN_STATE_LOGGER)
+            .expect("state_logger schema should exist");
 
         assert!(schema
             .fields

--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -3,6 +3,7 @@ pub mod command;
 
 pub use actor::IntegrationHandle;
 
+use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::db::config_queries;
 use crate::integrations::cron::Cron;
 use crate::integrations::{
@@ -18,7 +19,6 @@ use crate::types::{
         IntegrationId, OutboundDeviceUpdatePolicy,
     },
 };
-use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::utils::cli::Cli;
 use color_eyre::Result;
 use eyre::eyre;
@@ -1089,8 +1089,8 @@ mod tests {
 
     #[test]
     fn state_logger_schema_exposes_logger_fields() {
-        let schema = integration_config_schema("state_logger")
-            .expect("state_logger schema should exist");
+        let schema =
+            integration_config_schema("state_logger").expect("state_logger schema should exist");
         let keys = schema
             .fields
             .iter()
@@ -1111,14 +1111,12 @@ mod tests {
 
     #[test]
     fn state_logger_schema_does_not_include_outbound_pacing_field() {
-        let schema = integration_config_schema("state_logger")
-            .expect("state_logger schema should exist");
+        let schema =
+            integration_config_schema("state_logger").expect("state_logger schema should exist");
 
-        assert!(
-            schema
-                .fields
-                .iter()
-                .all(|field| field.key != "outbound_device_updates.min_interval_ms")
-        );
+        assert!(schema
+            .fields
+            .iter()
+            .all(|field| field.key != "outbound_device_updates.min_interval_ms"));
     }
 }

--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -162,7 +162,9 @@ impl Integrations {
         changes: SnapshotChanges,
     ) {
         for handle in self.custom_integrations.values() {
-            handle.runtime_state_changed(previous.clone(), current.clone(), changes);
+            if handle.wants_runtime_state_changes() {
+                handle.runtime_state_changed(previous.clone(), current.clone(), changes);
+            }
         }
     }
 

--- a/server/src/core/integrations/mod.rs
+++ b/server/src/core/integrations/mod.rs
@@ -732,16 +732,6 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                 ),
                 with_help_text(
                     text_config_field(
-                        "value_path",
-                        "Value path",
-                        true,
-                        "JSON pointer evaluated against the serialized device state.",
-                        Some("/value"),
-                    ),
-                    "JSON Pointer syntax. The path is evaluated against the serialized device state, so it should start with /. Use / between keys, for example /value, /state/power or /state/color/h.",
-                ),
-                with_help_text(
-                    text_config_field(
                         "postgresql_url",
                         "PostgreSQL URL",
                         false,
@@ -749,6 +739,16 @@ fn integration_config_schema(plugin: &str) -> Option<IntegrationConfigSchema> {
                         Some("postgresql://user:password@host:5432/database"),
                     ),
                     "Leave this empty to reuse the app's DATABASE_URL connection. If set, state_logger writes to this database instead of the PostgreSQL connection used by HomeCTL. The schema used is `public` and the name of the database is `state_logger_events`.",
+                ),
+                with_help_text(
+                    text_config_field(
+                        "value_path",
+                        "Value path",
+                        true,
+                        "JSON pointer evaluated against the serialized device state.",
+                        Some("/value"),
+                    ),
+                    "JSON Pointer syntax. The path is evaluated against the serialized device state, so it should start with /. Use / between keys, for example /value, /state/power or /state/color/h.",
                 ),
             ],
         )),

--- a/server/src/core/logs.rs
+++ b/server/src/core/logs.rs
@@ -102,8 +102,8 @@ fn write_log_buffer() -> RwLockWriteGuard<'static, VecDeque<UiLogEntry>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        log_filters_from_env_or_default, map_level, push_log_entry, recent_logs,
-        write_log_buffer, DEFAULT_LOG_FILTERS, MAX_LOG_ENTRIES,
+        log_filters_from_env_or_default, map_level, push_log_entry, recent_logs, write_log_buffer,
+        DEFAULT_LOG_FILTERS, MAX_LOG_ENTRIES,
     };
     use crate::types::logs::{LogLevel, UiLogEntry};
 

--- a/server/src/core/routine_history.rs
+++ b/server/src/core/routine_history.rs
@@ -97,6 +97,7 @@ mod tests {
         recent_routine_history, record_force_trigger, record_rule_match, write_history_buffer,
         MAX_ROUTINE_HISTORY_ENTRIES,
     };
+    use crate::core::integrations::PLUGIN_DUMMY;
     use crate::types::{
         device::{DeviceId, DeviceKey},
         integration::IntegrationId,
@@ -127,7 +128,7 @@ mod tests {
                 &RoutineId(format!("routine-{index}")),
                 "Routine",
                 Some(&DeviceKey::new(
-                    IntegrationId::from("dummy".to_string()),
+                    IntegrationId::from(PLUGIN_DUMMY.to_string()),
                     DeviceId::from(index.to_string()),
                 )),
                 1,

--- a/server/src/core/routines.rs
+++ b/server/src/core/routines.rs
@@ -73,18 +73,25 @@ fn expand_action_source_context(
         None => Vec::new(),
     };
 
+    // Split the activation arms so the guarded branch only runs when
+    // `include_source_groups` is set, while the fallback branch still handles
+    // rollout-source replacement for actions that do not merge groups.
     match &mut action {
         Action::ActivateScene(ActivateSceneActionDescriptor {
             group_keys,
             include_source_groups,
             rollout_source_device_key,
             ..
-        }) => {
-            if *include_source_groups {
-                merge_source_groups(group_keys, &source_groups);
-                *include_source_groups = false;
-            }
+        }) if *include_source_groups => {
+            merge_source_groups(group_keys, &source_groups);
+            *include_source_groups = false;
 
+            resolve_triggering_device_rollout_source(rollout_source_device_key, event_source);
+        }
+        Action::ActivateScene(ActivateSceneActionDescriptor {
+            rollout_source_device_key,
+            ..
+        }) => {
             resolve_triggering_device_rollout_source(rollout_source_device_key, event_source);
         }
         Action::CycleScenes(CycleScenesDescriptor {
@@ -93,26 +100,28 @@ fn expand_action_source_context(
             rollout_source_device_key,
             scenes,
             ..
-        }) => {
-            if *include_source_groups {
-                merge_source_groups(group_keys, &source_groups);
-                for scene in scenes.iter_mut() {
-                    merge_source_groups(&mut scene.group_keys, &source_groups);
-                }
-                *include_source_groups = false;
+        }) if *include_source_groups => {
+            merge_source_groups(group_keys, &source_groups);
+            for scene in scenes.iter_mut() {
+                merge_source_groups(&mut scene.group_keys, &source_groups);
             }
+            *include_source_groups = false;
 
+            resolve_triggering_device_rollout_source(rollout_source_device_key, event_source);
+        }
+        Action::CycleScenes(CycleScenesDescriptor {
+            rollout_source_device_key,
+            ..
+        }) => {
             resolve_triggering_device_rollout_source(rollout_source_device_key, event_source);
         }
         Action::Dim(DimDescriptor {
             group_keys,
             include_source_groups,
             ..
-        }) => {
-            if *include_source_groups {
-                merge_source_groups(group_keys, &source_groups);
-                *include_source_groups = false;
-            }
+        }) if *include_source_groups => {
+            merge_source_groups(group_keys, &source_groups);
+            *include_source_groups = false;
         }
         _ => {}
     }

--- a/server/src/core/routines.rs
+++ b/server/src/core/routines.rs
@@ -832,6 +832,7 @@ mod tests {
     use super::{
         evaluate_raw_rule_match, expand_action_source_context, Routines, RuleEvaluationContext,
     };
+    use crate::core::integrations::PLUGIN_MQTT;
     use crate::core::{devices::Devices, groups::Groups};
     use crate::types::action::{Action, Actions};
     use crate::types::device::{Device, DeviceData, DeviceId, DeviceKey, DeviceRef, SensorDevice};
@@ -859,7 +860,7 @@ mod tests {
 
     fn sensor_device(raw: serde_json::Value) -> Device {
         Device::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new("sensor"),
             "Sensor".to_string(),
             DeviceData::Sensor(SensorDevice::Text {
@@ -876,7 +877,7 @@ mod tests {
             value,
             trigger_mode: TriggerMode::Pulse,
             device_ref: DeviceRef::new_with_id(
-                IntegrationId::from("mqtt".to_string()),
+                IntegrationId::from(PLUGIN_MQTT.to_string()),
                 DeviceId::new("sensor"),
             ),
         }
@@ -904,7 +905,7 @@ mod tests {
 
     fn sensor_key() -> DeviceKey {
         DeviceKey::new(
-            IntegrationId::from("mqtt".to_string()),
+            IntegrationId::from(PLUGIN_MQTT.to_string()),
             DeviceId::new("sensor"),
         )
     }
@@ -940,7 +941,7 @@ mod tests {
             value: Some(json!("^button_(press|hold)$")),
             trigger_mode: TriggerMode::Pulse,
             device_ref: DeviceRef::new_with_id(
-                IntegrationId::from("mqtt".to_string()),
+                IntegrationId::from(PLUGIN_MQTT.to_string()),
                 DeviceId::new("sensor"),
             ),
         };

--- a/server/src/core/scenes.rs
+++ b/server/src/core/scenes.rs
@@ -404,8 +404,8 @@ fn find_active_scene_index(
             // then check if any of them have this scene active.
             // Offline devices are skipped (ignored) rather than causing detection to fail.
             let result = scene_devices_config
-                .iter()
-                .filter_map(|(device_key, _)| {
+                .keys()
+                .filter_map(|device_key| {
                     // only consider devices which are common across all cycled scenes
                     if !scenes_common_devices.contains(device_key) {
                         return None;

--- a/server/src/core/simulate.rs
+++ b/server/src/core/simulate.rs
@@ -19,6 +19,8 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use crate::core::integrations::{PLUGIN_DUMMY, PLUGIN_MQTT};
+
 /// Load config for simulation from a source database when available, or from the
 /// optional JSON backup config file otherwise.
 pub async fn prepare_simulation_config(
@@ -725,7 +727,7 @@ pub fn convert_mqtt_to_dummy(config: &mut ConfigExport) -> Result<()> {
     let mqtt_ids: Vec<String> = config
         .integrations
         .iter()
-        .filter(|i| i.plugin == "mqtt")
+        .filter(|i| i.plugin == PLUGIN_MQTT)
         .map(|i| i.id.clone())
         .collect();
 
@@ -789,7 +791,7 @@ pub fn convert_mqtt_to_dummy(config: &mut ConfigExport) -> Result<()> {
         let dummy_config = json!({ "devices": devices });
         let row = IntegrationRow {
             id: mqtt_id.to_string(),
-            plugin: "dummy".to_string(),
+            plugin: PLUGIN_DUMMY.to_string(),
             config: dummy_config,
             enabled: true,
         };
@@ -935,6 +937,7 @@ fn collect_device_refs_from_rules(
 #[cfg(test)]
 mod tests {
     use super::export_from_config_file;
+    use crate::core::integrations::PLUGIN_DUMMY;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -984,7 +987,7 @@ mod tests {
 
         assert_eq!(config.core.warmup_time_seconds, 3);
         assert_eq!(config.integrations.len(), 1);
-        assert_eq!(config.integrations[0].plugin, "dummy");
+        assert_eq!(config.integrations[0].plugin, PLUGIN_DUMMY);
 
         fs::remove_file(path).expect("temp config file should be removed");
     }

--- a/server/src/core/state/actor.rs
+++ b/server/src/core/state/actor.rs
@@ -162,6 +162,7 @@ async fn run_actor(
     use crate::core::event::handle_event;
 
     while let Some(cmd) = rx.recv().await {
+        let previous_snapshot = app_state.snapshot.load().clone();
         metrics.on_dequeue();
         let kind_idx = metrics::kind_index_for_command(&cmd);
         watchdog_kind.store(kind_idx, Ordering::SeqCst);
@@ -186,6 +187,14 @@ async fn run_actor(
                 let publish_started_at = Instant::now();
                 app_state.publish_snapshot(snapshot_changes);
                 let publish_elapsed = publish_started_at.elapsed();
+
+                let current_snapshot = app_state.snapshot.load().clone();
+
+                app_state.integrations.notify_runtime_state_changed(
+                    &previous_snapshot,
+                    &current_snapshot,
+                    snapshot_changes,
+                );
 
                 let elapsed = started_at.elapsed();
                 let slow = elapsed > Duration::from_millis(SLOW_EVENT_MUTATION_WARN_MS);
@@ -222,6 +231,14 @@ async fn run_actor(
                 let publish_started_at = Instant::now();
                 app_state.publish_snapshot(SnapshotChanges::all());
                 let publish_elapsed = publish_started_at.elapsed();
+
+                let current_snapshot = app_state.snapshot.load().clone();
+
+                app_state.integrations.notify_runtime_state_changed(
+                    &previous_snapshot,
+                    &current_snapshot,
+                    SnapshotChanges::all(),
+                );
 
                 let elapsed = started_at.elapsed();
                 let slow = elapsed > Duration::from_millis(SLOW_EVENT_MUTATION_WARN_MS);

--- a/server/src/core/state/actor.rs
+++ b/server/src/core/state/actor.rs
@@ -162,7 +162,6 @@ async fn run_actor(
     use crate::core::event::handle_event;
 
     while let Some(cmd) = rx.recv().await {
-        let previous_snapshot = app_state.snapshot.load().clone();
         metrics.on_dequeue();
         let kind_idx = metrics::kind_index_for_command(&cmd);
         watchdog_kind.store(kind_idx, Ordering::SeqCst);
@@ -175,6 +174,7 @@ async fn run_actor(
 
         match cmd {
             StateCommand::HandleEvent { event, done } => {
+                let previous_snapshot = app_state.snapshot.load().clone();
                 let kind = event_kind(&event);
                 let handle_started_at = Instant::now();
                 let outcome = handle_event(&mut app_state, &event).await;
@@ -224,6 +224,7 @@ async fn run_actor(
                 }
             }
             StateCommand::Mutate(f) => {
+                let previous_snapshot = app_state.snapshot.load().clone();
                 let mutate_started_at = Instant::now();
                 f(&mut app_state).await;
                 let mutate_elapsed = mutate_started_at.elapsed();

--- a/server/src/db/config_queries.rs
+++ b/server/src/db/config_queries.rs
@@ -50,7 +50,11 @@ pub struct SceneRow {
     pub name: String,
     pub hidden: bool,
     pub script: Option<String>,
+    // Need these so that one can create an empty scene
+    // and then populate these later when configuring.
+    #[serde(default)]
     pub device_states: HashMap<String, serde_json::Value>,
+    #[serde(default)]
     pub group_states: HashMap<String, serde_json::Value>,
 }
 

--- a/server/src/db/migrations/mod.rs
+++ b/server/src/db/migrations/mod.rs
@@ -1,8 +1,8 @@
 use crate::db::schema::{
     ConfigVersions, CoreConfig, DashboardLayouts, DashboardWidgets, DeviceDisplayOverrides,
     DeviceSensorConfigs, Devices, Floorplans, GroupDevices, GroupLinks, GroupPositions, Groups,
-    Integrations, Routines, SceneDeviceStates, SceneGroupStates, SceneOverrides, Scenes, UiState,
-    WidgetSettings,
+    Integrations, Routines, SceneDeviceStates, SceneGroupStates, SceneOverrides, Scenes,
+    StateDeviceEvents, StateLoggerEvents, UiState, WidgetSettings,
 };
 use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm_migration::prelude::*;
@@ -15,6 +15,8 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(M20260227000000Init),
             Box::new(M20260420000000DashboardWidgetSources),
+            Box::new(M20260527000000StateAuditLog),
+            Box::new(M20260529000000StateLoggerEvents),
         ]
     }
 }
@@ -106,6 +108,60 @@ impl MigrationTrait for M20260420000000DashboardWidgetSources {
             .drop_table(
                 Table::drop()
                     .table(WidgetSettings::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+struct M20260527000000StateAuditLog;
+
+impl MigrationName for M20260527000000StateAuditLog {
+    fn name(&self) -> &str {
+        "m20260527000000_state_audit_log"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for M20260527000000StateAuditLog {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        create_state_device_events(manager).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(StateDeviceEvents::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+struct M20260529000000StateLoggerEvents;
+
+impl MigrationName for M20260529000000StateLoggerEvents {
+    fn name(&self) -> &str {
+        "m20260529000000_state_logger_events"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for M20260529000000StateLoggerEvents {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        create_state_logger_events(manager).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(StateLoggerEvents::Table)
                     .if_exists()
                     .to_owned(),
             )
@@ -736,6 +792,113 @@ async fn create_widget_settings(manager: &SchemaManager<'_>) -> Result<(), DbErr
                         .timestamp()
                         .default(Expr::current_timestamp()),
                 )
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_state_device_events(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(StateDeviceEvents::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(StateDeviceEvents::Id)
+                        .integer()
+                        .not_null()
+                        .auto_increment()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(StateDeviceEvents::DeviceKey).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::IntegrationId).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::DeviceId).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::DeviceName).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::DeviceKind).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::EventKind).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::DeviceStateJson).text().not_null())
+                .col(ColumnDef::new(StateDeviceEvents::Value).double().null())
+                .col(
+                    ColumnDef::new(StateDeviceEvents::CreatedAt)
+                        .timestamp()
+                        .default(Expr::current_timestamp()),
+                )
+                .to_owned(),
+        )
+        .await
+        ?;
+
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_state_device_events_device_key")
+                .table(StateDeviceEvents::Table)
+                .col(StateDeviceEvents::DeviceKey)
+                .if_not_exists()
+                .to_owned(),
+        )
+        .await?;
+
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_state_device_events_created_at")
+                .table(StateDeviceEvents::Table)
+                .col(StateDeviceEvents::CreatedAt)
+                .if_not_exists()
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_state_logger_events(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(StateLoggerEvents::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(StateLoggerEvents::Id)
+                        .integer()
+                        .not_null()
+                        .auto_increment()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(StateLoggerEvents::DeviceKey).text().not_null())
+                .col(
+                    ColumnDef::new(StateLoggerEvents::CreatedAt)
+                    .timestamp_with_time_zone()
+                        .default(Expr::current_timestamp()),
+                )
+                .col(ColumnDef::new(StateLoggerEvents::IntegrationId).text().not_null())
+                .col(ColumnDef::new(StateLoggerEvents::DeviceId).text().not_null())
+                .col(ColumnDef::new(StateLoggerEvents::DeviceName).text().not_null())
+                .col(ColumnDef::new(StateLoggerEvents::DeviceKind).text().not_null())
+                .col(ColumnDef::new(StateLoggerEvents::EventKind).text().not_null())
+                .col(ColumnDef::new(StateLoggerEvents::DeviceStateJson).text().not_null())
+                .col(ColumnDef::new(StateLoggerEvents::Value).double().null())
+                .to_owned(),
+        )
+        .await?;
+
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_state_logger_events_device_key")
+                .table(StateLoggerEvents::Table)
+                .col(StateLoggerEvents::DeviceKey)
+                .if_not_exists()
+                .to_owned(),
+        )
+        .await?;
+
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_state_logger_events_created_at")
+                .table(StateLoggerEvents::Table)
+                .col(StateLoggerEvents::CreatedAt)
+                .if_not_exists()
                 .to_owned(),
         )
         .await

--- a/server/src/db/migrations/mod.rs
+++ b/server/src/db/migrations/mod.rs
@@ -15,7 +15,6 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(M20260227000000Init),
             Box::new(M20260420000000DashboardWidgetSources),
-            Box::new(M20260527000000StateAuditLog),
             Box::new(M20260529000000StateLoggerEvents),
         ]
     }
@@ -108,33 +107,6 @@ impl MigrationTrait for M20260420000000DashboardWidgetSources {
             .drop_table(
                 Table::drop()
                     .table(WidgetSettings::Table)
-                    .if_exists()
-                    .to_owned(),
-            )
-            .await
-    }
-}
-
-struct M20260527000000StateAuditLog;
-
-impl MigrationName for M20260527000000StateAuditLog {
-    fn name(&self) -> &str {
-        "m20260527000000_state_audit_log"
-    }
-}
-
-#[async_trait::async_trait]
-impl MigrationTrait for M20260527000000StateAuditLog {
-    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        create_state_device_events(manager).await?;
-        Ok(())
-    }
-
-    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager
-            .drop_table(
-                Table::drop()
-                    .table(StateDeviceEvents::Table)
                     .if_exists()
                     .to_owned(),
             )

--- a/server/src/db/migrations/mod.rs
+++ b/server/src/db/migrations/mod.rs
@@ -4,7 +4,9 @@ use crate::db::schema::{
     Integrations, Routines, SceneDeviceStates, SceneGroupStates, SceneOverrides, Scenes,
     StateLoggerEvents, UiState, WidgetSettings,
 };
+use log::info;
 use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::{ConnectionTrait, Statement};
 use sea_orm_migration::prelude::*;
 
 pub struct Migrator;
@@ -139,6 +141,44 @@ impl MigrationTrait for M20260529000000StateLoggerEvents {
             )
             .await
     }
+}
+
+// Apply only the state_logger events migration against a specific connection.
+// This is used by integrations that create their own dedicated DB connection
+// so they can ensure the `state_logger_events` table exists without running
+// the full migrator.
+pub async fn ensure_state_logger_events_on_connection(
+    conn: &sea_orm::DatabaseConnection,
+) -> Result<(), DbErr> {
+    let backend = conn.get_database_backend();
+
+    // Check whether the table already exists on this connection.
+    let exists = match backend {
+        sea_orm::DbBackend::Postgres => {
+            let sql = "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='state_logger_events' LIMIT 1";
+            conn.query_one(Statement::from_string(backend, sql.to_string()))
+                .await?
+                .is_some()
+        }
+        sea_orm::DbBackend::Sqlite => {
+            let sql = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='state_logger_events' LIMIT 1";
+            conn.query_one(Statement::from_string(backend, sql.to_string()))
+                .await?
+                .is_some()
+        }
+        _ => false,
+    };
+
+    if exists {
+        info!("state_logger: state_logger_events table already exists on dedicated DB; skipping migration");
+        return Ok(());
+    }
+
+    let manager = SchemaManager::new(conn);
+    create_state_logger_events(&manager).await?;
+    info!("state_logger: created state_logger_events table on dedicated DB");
+
+    Ok(())
 }
 
 async fn create_devices(manager: &SchemaManager<'_>) -> Result<(), DbErr> {

--- a/server/src/db/migrations/mod.rs
+++ b/server/src/db/migrations/mod.rs
@@ -810,13 +810,41 @@ async fn create_state_device_events(manager: &SchemaManager<'_>) -> Result<(), D
                         .auto_increment()
                         .primary_key(),
                 )
-                .col(ColumnDef::new(StateDeviceEvents::DeviceKey).text().not_null())
-                .col(ColumnDef::new(StateDeviceEvents::IntegrationId).text().not_null())
-                .col(ColumnDef::new(StateDeviceEvents::DeviceId).text().not_null())
-                .col(ColumnDef::new(StateDeviceEvents::DeviceName).text().not_null())
-                .col(ColumnDef::new(StateDeviceEvents::DeviceKind).text().not_null())
-                .col(ColumnDef::new(StateDeviceEvents::EventKind).text().not_null())
-                .col(ColumnDef::new(StateDeviceEvents::DeviceStateJson).text().not_null())
+                .col(
+                    ColumnDef::new(StateDeviceEvents::DeviceKey)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateDeviceEvents::IntegrationId)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateDeviceEvents::DeviceId)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateDeviceEvents::DeviceName)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateDeviceEvents::DeviceKind)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateDeviceEvents::EventKind)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateDeviceEvents::DeviceStateJson)
+                        .text()
+                        .not_null(),
+                )
                 .col(ColumnDef::new(StateDeviceEvents::Value).double().null())
                 .col(
                     ColumnDef::new(StateDeviceEvents::CreatedAt)
@@ -825,8 +853,7 @@ async fn create_state_device_events(manager: &SchemaManager<'_>) -> Result<(), D
                 )
                 .to_owned(),
         )
-        .await
-        ?;
+        .await?;
 
     manager
         .create_index(
@@ -864,18 +891,46 @@ async fn create_state_logger_events(manager: &SchemaManager<'_>) -> Result<(), D
                         .auto_increment()
                         .primary_key(),
                 )
-                .col(ColumnDef::new(StateLoggerEvents::DeviceKey).text().not_null())
+                .col(
+                    ColumnDef::new(StateLoggerEvents::DeviceKey)
+                        .text()
+                        .not_null(),
+                )
                 .col(
                     ColumnDef::new(StateLoggerEvents::CreatedAt)
-                    .timestamp_with_time_zone()
+                        .timestamp_with_time_zone()
                         .default(Expr::current_timestamp()),
                 )
-                .col(ColumnDef::new(StateLoggerEvents::IntegrationId).text().not_null())
-                .col(ColumnDef::new(StateLoggerEvents::DeviceId).text().not_null())
-                .col(ColumnDef::new(StateLoggerEvents::DeviceName).text().not_null())
-                .col(ColumnDef::new(StateLoggerEvents::DeviceKind).text().not_null())
-                .col(ColumnDef::new(StateLoggerEvents::EventKind).text().not_null())
-                .col(ColumnDef::new(StateLoggerEvents::DeviceStateJson).text().not_null())
+                .col(
+                    ColumnDef::new(StateLoggerEvents::IntegrationId)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateLoggerEvents::DeviceId)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateLoggerEvents::DeviceName)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateLoggerEvents::DeviceKind)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateLoggerEvents::EventKind)
+                        .text()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(StateLoggerEvents::DeviceStateJson)
+                        .text()
+                        .not_null(),
+                )
                 .col(ColumnDef::new(StateLoggerEvents::Value).double().null())
                 .to_owned(),
         )

--- a/server/src/db/migrations/mod.rs
+++ b/server/src/db/migrations/mod.rs
@@ -769,7 +769,6 @@ async fn create_widget_settings(manager: &SchemaManager<'_>) -> Result<(), DbErr
         .await
 }
 
-
 async fn create_state_logger_events(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     manager
         .create_table(

--- a/server/src/db/migrations/mod.rs
+++ b/server/src/db/migrations/mod.rs
@@ -2,7 +2,7 @@ use crate::db::schema::{
     ConfigVersions, CoreConfig, DashboardLayouts, DashboardWidgets, DeviceDisplayOverrides,
     DeviceSensorConfigs, Devices, Floorplans, GroupDevices, GroupLinks, GroupPositions, Groups,
     Integrations, Routines, SceneDeviceStates, SceneGroupStates, SceneOverrides, Scenes,
-    StateDeviceEvents, StateLoggerEvents, UiState, WidgetSettings,
+    StateLoggerEvents, UiState, WidgetSettings,
 };
 use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm_migration::prelude::*;
@@ -769,86 +769,6 @@ async fn create_widget_settings(manager: &SchemaManager<'_>) -> Result<(), DbErr
         .await
 }
 
-async fn create_state_device_events(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
-    manager
-        .create_table(
-            Table::create()
-                .table(StateDeviceEvents::Table)
-                .if_not_exists()
-                .col(
-                    ColumnDef::new(StateDeviceEvents::Id)
-                        .integer()
-                        .not_null()
-                        .auto_increment()
-                        .primary_key(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::DeviceKey)
-                        .text()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::IntegrationId)
-                        .text()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::DeviceId)
-                        .text()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::DeviceName)
-                        .text()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::DeviceKind)
-                        .text()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::EventKind)
-                        .text()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(StateDeviceEvents::DeviceStateJson)
-                        .text()
-                        .not_null(),
-                )
-                .col(ColumnDef::new(StateDeviceEvents::Value).double().null())
-                .col(
-                    ColumnDef::new(StateDeviceEvents::CreatedAt)
-                        .timestamp()
-                        .default(Expr::current_timestamp()),
-                )
-                .to_owned(),
-        )
-        .await?;
-
-    manager
-        .create_index(
-            Index::create()
-                .name("idx_state_device_events_device_key")
-                .table(StateDeviceEvents::Table)
-                .col(StateDeviceEvents::DeviceKey)
-                .if_not_exists()
-                .to_owned(),
-        )
-        .await?;
-
-    manager
-        .create_index(
-            Index::create()
-                .name("idx_state_device_events_created_at")
-                .table(StateDeviceEvents::Table)
-                .col(StateDeviceEvents::CreatedAt)
-                .if_not_exists()
-                .to_owned(),
-        )
-        .await
-}
 
 async fn create_state_logger_events(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     manager

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -20,10 +20,34 @@ const DEFAULT_SQLITE_DATABASE_FILE: &str = "homectl.db";
 // and harmless in usernames, while still percent-encoding characters
 // such as '@', '/', '?', '#', ':', whitespace, and other punctuation.
 const POSTGRES_USERINFO_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-    .add(b' ')  .add(b'!')  .add(b'"') .add(b'#')  .add(b'$')  .add(b'%')  .add(b'&')
-    .add(b'\'') .add(b'(')  .add(b')')  .add(b'*')  .add(b'+')  .add(b',')  .add(b'/')
-    .add(b':')  .add(b';')  .add(b'<')  .add(b'=')  .add(b'>')  .add(b'?')  .add(b'@')
-    .add(b'[')  .add(b'\\') .add(b']')  .add(b'^')  .add(b'`')  .add(b'{')  .add(b'|')
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
     .add(b'}');
 
 static DB_CONNECTION: OnceCell<DatabaseConnection> = OnceCell::new();
@@ -112,7 +136,10 @@ async fn connect_database(target: &DatabaseTarget) -> Result<bool> {
 
     ensure_database_exists(target).await?;
 
-    info!("Connecting to database at {}...", redact_postgres_password(&target.url));
+    info!(
+        "Connecting to database at {}...",
+        redact_postgres_password(&target.url)
+    );
     let mut options = ConnectOptions::new(target.url.clone());
     options.acquire_timeout(Duration::from_secs(2));
 
@@ -354,8 +381,7 @@ fn redact_postgres_password(database_url: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_postgres_database_url,
-        normalize_postgres_userinfo_component,
+        normalize_postgres_database_url, normalize_postgres_userinfo_component,
         redact_postgres_password,
     };
 

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,7 +1,7 @@
 use color_eyre::Result;
 use eyre::eyre;
-use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
 use once_cell::sync::OnceCell;
+use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 use sea_orm_migration::MigratorTrait;
 use sqlx::migrate::MigrateDatabase;

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,5 +1,6 @@
 use color_eyre::Result;
 use eyre::eyre;
+use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
 use once_cell::sync::OnceCell;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 use sea_orm_migration::MigratorTrait;
@@ -13,6 +14,7 @@ pub mod migrations;
 pub mod schema;
 
 const DEFAULT_SQLITE_DATABASE_FILE: &str = "homectl.db";
+const POSTGRES_USERINFO_ENCODE_SET: &percent_encoding::AsciiSet = NON_ALPHANUMERIC;
 
 static DB_CONNECTION: OnceCell<DatabaseConnection> = OnceCell::new();
 static DATABASE_TARGET: OnceCell<DatabaseTarget> = OnceCell::new();
@@ -122,13 +124,15 @@ async fn ensure_database_exists(target: &DatabaseTarget) -> Result<()> {
 }
 
 async fn ensure_postgres_database_exists(database_url: &str) -> Result<()> {
-    if Postgres::database_exists(database_url).await? {
+    let database_url = normalize_postgres_database_url(database_url);
+
+    if Postgres::database_exists(&database_url).await? {
         return Ok(());
     }
 
     info!("Creating PostgreSQL database referenced by DATABASE_URL...");
 
-    match Postgres::create_database(database_url).await {
+    match Postgres::create_database(&database_url).await {
         Ok(()) => Ok(()),
         Err(error) if is_duplicate_database_error(&error) => Ok(()),
         Err(error) => Err(error.into()),
@@ -189,7 +193,7 @@ impl DatabaseTarget {
     fn explicit(database_url: &str) -> Result<Self> {
         let backend = DatabaseBackendKind::from_url(database_url)?;
         let url = match backend {
-            DatabaseBackendKind::Postgres => database_url.to_string(),
+            DatabaseBackendKind::Postgres => normalize_postgres_database_url(database_url),
             DatabaseBackendKind::Sqlite => normalize_sqlite_database_url(database_url),
         };
 
@@ -260,4 +264,86 @@ fn is_sqlite_memory_url(database_url: &str) -> bool {
     database_url == "sqlite::memory:"
         || database_url.starts_with("sqlite://:memory:")
         || database_url.contains("mode=memory")
+}
+
+fn normalize_postgres_database_url(database_url: &str) -> String {
+    let Some((scheme, rest)) = database_url.split_once("://") else {
+        return database_url.to_string();
+    };
+
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let (authority, tail) = rest.split_at(authority_end);
+
+    let Some(at_index) = authority.rfind('@') else {
+        return database_url.to_string();
+    };
+
+    let (userinfo, host) = authority.split_at(at_index);
+    let host = &host[1..];
+
+    let (username, password) = match userinfo.split_once(':') {
+        Some((username, password)) => (username, Some(password)),
+        None => (userinfo, None),
+    };
+
+    let username = normalize_postgres_userinfo_component(username);
+    let password = password.map(normalize_postgres_userinfo_component);
+
+    let mut normalized = format!("{scheme}://{username}");
+    if let Some(password) = password {
+        normalized.push(':');
+        normalized.push_str(&password);
+    }
+    normalized.push('@');
+    normalized.push_str(host);
+    normalized.push_str(tail);
+    normalized
+}
+
+fn normalize_postgres_userinfo_component(component: &str) -> String {
+    let decoded = percent_decode_str(component).decode_utf8_lossy();
+    utf8_percent_encode(&decoded, POSTGRES_USERINFO_ENCODE_SET).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_postgres_database_url, normalize_postgres_userinfo_component};
+
+    #[test]
+    fn normalizes_raw_postgres_credentials() {
+        let url = "postgres://user:pa(ss)w@rd@localhost:5432/postgres";
+
+        assert_eq!(
+            normalize_postgres_database_url(url),
+            "postgres://user:pa%28ss%29w%40rd@localhost:5432/postgres"
+        );
+    }
+
+    #[test]
+    fn preserves_already_encoded_postgres_credentials() {
+        let url = "postgres://user:pa%28ss%29w%40rd@localhost:5432/postgres";
+
+        assert_eq!(
+            normalize_postgres_database_url(url),
+            "postgres://user:pa%28ss%29w%40rd@localhost:5432/postgres"
+        );
+    }
+
+    #[test]
+    fn normalizes_individual_userinfo_component() {
+        assert_eq!(
+            normalize_postgres_userinfo_component("pa(ss)w@rd"),
+            "pa%28ss%29w%40rd"
+        );
+    }
+
+    #[test]
+    fn normalizes_punctuation_heavy_postgres_credentials() {
+        let url = "postgres://foo.bar-baz:pa(ss)w@rd&1*2@127.0.0.1:5432/homectl";
+
+        assert_eq!(
+            normalize_postgres_database_url(url),
+            "postgres://foo%2Ebar%2Dbaz:pa%28ss%29w%40rd%261%2A2@127.0.0.1:5432/homectl"
+        );
+    }
 }

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,7 +1,7 @@
 use color_eyre::Result;
 use eyre::eyre;
 use once_cell::sync::OnceCell;
-use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{percent_decode_str, utf8_percent_encode};
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 use sea_orm_migration::MigratorTrait;
 use sqlx::migrate::MigrateDatabase;
@@ -14,7 +14,17 @@ pub mod migrations;
 pub mod schema;
 
 const DEFAULT_SQLITE_DATABASE_FILE: &str = "homectl.db";
-const POSTGRES_USERINFO_ENCODE_SET: &percent_encoding::AsciiSet = NON_ALPHANUMERIC;
+// Encode punctuation that can break URL parsing, but preserve RFC3986
+// unreserved characters: ALPHA / DIGIT / '-' / '.' / '_' / '~'.
+// This avoids re-encoding characters like '.' and '-' which are common
+// and harmless in usernames, while still percent-encoding characters
+// such as '@', '/', '?', '#', ':', whitespace, and other punctuation.
+const POSTGRES_USERINFO_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+    .add(b' ')  .add(b'!')  .add(b'"') .add(b'#')  .add(b'$')  .add(b'%')  .add(b'&')
+    .add(b'\'') .add(b'(')  .add(b')')  .add(b'*')  .add(b'+')  .add(b',')  .add(b'/')
+    .add(b':')  .add(b';')  .add(b'<')  .add(b'=')  .add(b'>')  .add(b'?')  .add(b'@')
+    .add(b'[')  .add(b'\\') .add(b']')  .add(b'^')  .add(b'`')  .add(b'{')  .add(b'|')
+    .add(b'}');
 
 static DB_CONNECTION: OnceCell<DatabaseConnection> = OnceCell::new();
 static DATABASE_TARGET: OnceCell<DatabaseTarget> = OnceCell::new();
@@ -102,7 +112,7 @@ async fn connect_database(target: &DatabaseTarget) -> Result<bool> {
 
     ensure_database_exists(target).await?;
 
-    info!("Connecting to database at {}...", target.url);
+    info!("Connecting to database at {}...", redact_postgres_password(&target.url));
     let mut options = ConnectOptions::new(target.url.clone());
     options.acquire_timeout(Duration::from_secs(2));
 
@@ -301,13 +311,53 @@ fn normalize_postgres_database_url(database_url: &str) -> String {
 }
 
 fn normalize_postgres_userinfo_component(component: &str) -> String {
-    let decoded = percent_decode_str(component).decode_utf8_lossy();
-    utf8_percent_encode(&decoded, POSTGRES_USERINFO_ENCODE_SET).to_string()
+    match percent_decode_str(component).decode_utf8() {
+        Ok(decoded) => utf8_percent_encode(&decoded, POSTGRES_USERINFO_ENCODE_SET).to_string(),
+        // If the userinfo component contains invalid percent-encoding or invalid
+        // UTF-8, avoid silently replacing bytes with U+FFFD; fall back to returning
+        // the original component unchanged so we don't corrupt credentials.
+        Err(_) => component.to_string(),
+    }
+}
+
+fn redact_postgres_password(database_url: &str) -> String {
+    let Some((scheme, rest)) = database_url.split_once("://") else {
+        return database_url.to_string();
+    };
+
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let (authority, tail) = rest.split_at(authority_end);
+
+    let Some(at_index) = authority.rfind('@') else {
+        return database_url.to_string();
+    };
+
+    let (userinfo, host) = authority.split_at(at_index);
+    let host = &host[1..];
+
+    let (username, password) = match userinfo.split_once(':') {
+        Some((username, password)) => (username, Some(password)),
+        None => (userinfo, None),
+    };
+
+    let mut result = format!("{scheme}://{username}");
+    if password.is_some() {
+        result.push(':');
+        result.push_str("<redacted>");
+    }
+    result.push('@');
+    result.push_str(host);
+    result.push_str(tail);
+    result
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_postgres_database_url, normalize_postgres_userinfo_component};
+    use super::{
+        normalize_postgres_database_url,
+        normalize_postgres_userinfo_component,
+        redact_postgres_password,
+    };
 
     #[test]
     fn normalizes_raw_postgres_credentials() {
@@ -343,7 +393,38 @@ mod tests {
 
         assert_eq!(
             normalize_postgres_database_url(url),
-            "postgres://foo%2Ebar%2Dbaz:pa%28ss%29w%40rd%261%2A2@127.0.0.1:5432/homectl"
+            "postgres://foo.bar-baz:pa%28ss%29w%40rd%261%2A2@127.0.0.1:5432/homectl"
         );
+    }
+
+    #[test]
+    fn redacts_password_when_logging() {
+        let url = "postgres://user:pa%28ss%29w%40rd@localhost:5432/postgres";
+        let redacted = redact_postgres_password(url);
+        assert!(redacted.contains("<redacted>"));
+        assert!(redacted.contains(":<redacted>@"));
+        assert!(!redacted.contains("pa%28ss%29w%40rd"));
+    }
+
+    #[test]
+    fn does_not_insert_redaction_when_no_password() {
+        let url = "postgres://user@localhost:5432/postgres";
+        let redacted = redact_postgres_password(url);
+        assert!(!redacted.contains("<redacted>"));
+        assert_eq!(redacted, url);
+    }
+
+    #[test]
+    fn leaves_sqlite_urls_untouched() {
+        let url = "sqlite://./homectl.db?mode=rwc";
+        let redacted = redact_postgres_password(url);
+        assert_eq!(redacted, url);
+    }
+
+    #[test]
+    fn leaves_urls_without_userinfo_untouched() {
+        let url = "postgres://localhost:5432/postgres";
+        let redacted = redact_postgres_password(url);
+        assert_eq!(redacted, url);
     }
 }

--- a/server/src/db/schema.rs
+++ b/server/src/db/schema.rs
@@ -180,6 +180,36 @@ pub enum ConfigVersions {
 }
 
 #[derive(Clone, Copy, Iden)]
+pub enum StateDeviceEvents {
+    Table,
+    Id,
+    DeviceKey,
+    IntegrationId,
+    DeviceId,
+    DeviceName,
+    DeviceKind,
+    EventKind,
+    DeviceStateJson,
+    Value,
+    CreatedAt,
+}
+
+#[derive(Clone, Copy, Iden)]
+pub enum StateLoggerEvents {
+    Table,
+    Id,
+    DeviceKey,
+    IntegrationId,
+    DeviceId,
+    DeviceName,
+    DeviceKind,
+    EventKind,
+    DeviceStateJson,
+    Value,
+    CreatedAt,
+}
+
+#[derive(Clone, Copy, Iden)]
 pub enum UiState {
     Table,
     Key,

--- a/server/src/integrations/mod.rs
+++ b/server/src/integrations/mod.rs
@@ -3,4 +3,5 @@ pub mod cron;
 pub mod dummy;
 pub mod mqtt;
 pub mod random;
+pub mod state_logger;
 pub mod timer;

--- a/server/src/integrations/mqtt/utils.rs
+++ b/server/src/integrations/mqtt/utils.rs
@@ -293,6 +293,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::core::integrations::PLUGIN_MQTT;
     use jsonptr::PointerBuf;
     use ordered_float::OrderedFloat;
     use serde_json::json;
@@ -304,7 +305,7 @@ mod tests {
         let device = Device {
             id: DeviceId::new("device1"),
             name: "Device 1".to_string(),
-            integration_id: IntegrationId::from_str("mqtt").unwrap(),
+            integration_id: IntegrationId::from_str(PLUGIN_MQTT).unwrap(),
             data: DeviceData::Controllable(ControllableDevice::new(
                 None,
                 true,
@@ -363,7 +364,7 @@ mod tests {
             ..Default::default()
         };
 
-        let integration_id = IntegrationId::from_str("mqtt").unwrap();
+        let integration_id = IntegrationId::from_str(PLUGIN_MQTT).unwrap();
         let device = mqtt_to_homectl(
             mqtt_json.to_string().as_bytes(),
             "homectl/devices/device1",
@@ -410,7 +411,7 @@ mod tests {
             ..Default::default()
         };
 
-        let integration_id = IntegrationId::from_str("mqtt").unwrap();
+        let integration_id = IntegrationId::from_str(PLUGIN_MQTT).unwrap();
         let device = mqtt_to_homectl(
             mqtt_json.to_string().as_bytes(),
             "homectl/devices/device1",
@@ -438,7 +439,7 @@ mod tests {
             ..Default::default()
         };
 
-        let integration_id = IntegrationId::from_str("mqtt").unwrap();
+        let integration_id = IntegrationId::from_str(PLUGIN_MQTT).unwrap();
         let device = mqtt_to_homectl(
             mqtt_json.to_string().as_bytes(),
             "zigbee2mqtt/remote_1",
@@ -474,7 +475,7 @@ mod tests {
             ..Default::default()
         };
 
-        let integration_id = IntegrationId::from_str("mqtt").unwrap();
+        let integration_id = IntegrationId::from_str(PLUGIN_MQTT).unwrap();
         let device = mqtt_to_homectl(
             mqtt_json.to_string().as_bytes(),
             "homectl/devices/device1",

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -10,12 +10,14 @@ use crate::{
 use async_trait::async_trait;
 use chrono::Utc;
 use color_eyre::{eyre::Context, Result};
-use once_cell::sync::OnceCell;
 use jsonptr::PointerBuf;
+use once_cell::sync::OnceCell;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use sea_orm::sea_query::Query;
-use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, Statement, StatementBuilder};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, Statement, StatementBuilder,
+};
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -26,7 +28,6 @@ enum PatternMatchMode {
     Glob,
     Regex,
 }
-
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct StateLoggerConfig {
@@ -276,9 +277,7 @@ impl StateLogger {
     fn database_source_label(&self) -> &'static str {
         match self.database {
             StateLoggerDatabase::Shared => "HomeCTL shared PG connection",
-            StateLoggerDatabase::Dedicated { .. } => {
-                "state_logger config option `postgresql_url`"
-            }
+            StateLoggerDatabase::Dedicated { .. } => "state_logger config option `postgresql_url`",
         }
     }
 
@@ -300,7 +299,9 @@ impl StateLogger {
                 ensure_state_logger_events_table(&database_connection).await?;
 
                 let _ = connection.set(database_connection);
-                Ok(connection.get().expect("dedicated connection should be set"))
+                Ok(connection
+                    .get()
+                    .expect("dedicated connection should be set"))
             }
         }
     }

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use color_eyre::{eyre::Context, Result};
 use eyre::eyre;
+use globset::GlobBuilder;
 use jsonptr::PointerBuf;
 use once_cell::sync::OnceCell;
 use regex::Regex;
@@ -53,8 +54,22 @@ enum StateLoggerDatabase {
 pub struct StateLogger {
     id: IntegrationId,
     config: StateLoggerConfig,
-    compiled_pattern: Regex,
+    compiled_pattern: PatternMatcher,
     database: StateLoggerDatabase,
+}
+
+enum PatternMatcher {
+    Regex(Regex),
+    Glob(globset::GlobMatcher),
+}
+
+impl PatternMatcher {
+    fn is_match(&self, text: &str) -> bool {
+        match self {
+            Self::Regex(regex) => regex.is_match(text),
+            Self::Glob(matcher) => matcher.is_match(text),
+        }
+    }
 }
 
 #[async_trait]
@@ -317,31 +332,14 @@ impl StateLogger {
     }
 }
 
-fn compile_pattern(pattern: &str, mode: PatternMatchMode) -> Result<Regex> {
-    let regex = match mode {
-        PatternMatchMode::Regex => pattern.to_string(),
-        PatternMatchMode::Glob => glob_to_regex(pattern),
-    };
-
-    Regex::new(&regex).map_err(Into::into)
-}
-
-fn glob_to_regex(pattern: &str) -> String {
-    // Do not anchor the generated regex by default. Let callers include
-    // explicit start/end anchors or wildcards in the pattern when desired.
-    let mut regex = String::new();
-    for character in pattern.chars() {
-        match character {
-            '*' => regex.push_str(".*"),
-            '?' => regex.push('.'),
-            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '[' | ']' | '\\' => {
-                regex.push('\\');
-                regex.push(character);
-            }
-            other => regex.push(other),
+fn compile_pattern(pattern: &str, mode: PatternMatchMode) -> Result<PatternMatcher> {
+    match mode {
+        PatternMatchMode::Regex => Ok(PatternMatcher::Regex(Regex::new(pattern)?)),
+        PatternMatchMode::Glob => {
+            let glob = GlobBuilder::new(&format!("*{pattern}*")).build()?;
+            Ok(PatternMatcher::Glob(glob.compile_matcher()))
         }
     }
-    regex
 }
 
 #[cfg(test)]
@@ -350,49 +348,69 @@ mod tests {
 
     #[test]
     fn glob_matches_substring_by_default() {
-        let re = compile_pattern("temp", PatternMatchMode::Glob).unwrap();
-        assert!(re.is_match("my-temp-device"));
-        assert!(re.is_match("temperature"));
-        // spaces in device names should match too
-        assert!(re.is_match("my temp device"));
-        assert!(re.is_match("temp sensor"));
+        let matcher = compile_pattern("temp", PatternMatchMode::Glob).unwrap();
+
+        assert!(matcher.is_match("my-temp-device"));
+        assert!(matcher.is_match("temperature"));
+        assert!(matcher.is_match("my temp device"));
+        assert!(matcher.is_match("temp sensor"));
+    }
+
+    #[test]
+    fn glob_matches_sensor_names() {
+        let matcher = compile_pattern("sensor-*", PatternMatchMode::Glob).unwrap();
+
+        assert!(matcher.is_match("sensor-123"));
+        assert!(matcher.is_match("prefix-sensor-123"));
+        assert!(!matcher.is_match("sensr-1"));
+    }
+
+    #[test]
+    fn glob_matches_living_room_names() {
+        let matcher = compile_pattern("living room*", PatternMatchMode::Glob).unwrap();
+
+        assert!(matcher.is_match("living room lamp"));
+        assert!(matcher.is_match("my living room lamp"));
+        assert!(!matcher.is_match("livingroom lamp"));
     }
 
     #[test]
     fn glob_wildcards() {
-        let re = compile_pattern("sensor-*", PatternMatchMode::Glob).unwrap();
-        assert!(re.is_match("sensor-1"));
-        // Unanchored patterns match substrings by default
-        assert!(re.is_match("prefix-sensor-1"));
-        assert!(!re.is_match("sensr-1"));
-        // wildcard should also match when device name contains spaces
-        let re2 = compile_pattern("sensor *", PatternMatchMode::Glob).unwrap();
-        assert!(re2.is_match("sensor lamp"));
-        assert!(re2.is_match("prefix sensor lamp"));
+        let matcher = compile_pattern("sensor *", PatternMatchMode::Glob).unwrap();
+
+        assert!(matcher.is_match("sensor lamp"));
+        assert!(matcher.is_match("prefix sensor lamp"));
     }
 
     #[test]
     fn glob_question_mark() {
-        let re = compile_pattern("dev?ce", PatternMatchMode::Glob).unwrap();
-        assert!(re.is_match("device"));
-        assert!(re.is_match("devXce"));
-        assert!(!re.is_match("devce"));
-        // question mark matches a single character including space
-        let re2 = compile_pattern("dev?ce", PatternMatchMode::Glob).unwrap();
-        assert!(re2.is_match("dev ce"));
+        let matcher = compile_pattern("dev?ce", PatternMatchMode::Glob).unwrap();
+
+        assert!(matcher.is_match("device"));
+        assert!(matcher.is_match("devXce"));
+        assert!(!matcher.is_match("devce"));
+        assert!(matcher.is_match("dev ce"));
     }
 
     #[test]
-    fn regex_mode_respects_anchors() {
-        let re = compile_pattern("^sensor-\\d+$", PatternMatchMode::Regex).unwrap();
-        assert!(re.is_match("sensor-123"));
-        assert!(!re.is_match("prefix-sensor-123"));
-        // regex anchors also handle spaces explicitly
-        let re2 = compile_pattern("^living room .+$", PatternMatchMode::Regex).unwrap();
-        assert!(re2.is_match("living room lamp"));
-        assert!(!re2.is_match("my living room lamp"));
-        let re3 = compile_pattern("living room*", PatternMatchMode::Regex).unwrap();
-        assert!(re3.is_match("living room lamp"));
-        assert!(re3.is_match("my living room lamp"));
+    fn regex_matches_sensor_names_with_anchors() {
+        let matcher = compile_pattern("^sensor-\\d+$", PatternMatchMode::Regex).unwrap();
+
+        assert!(matcher.is_match("sensor-123"));
+        assert!(!matcher.is_match("prefix-sensor-123"));
+        assert!(!matcher.is_match("sensr-1"));
+    }
+
+    #[test]
+    fn regex_matches_living_room_names_with_anchors() {
+        let matcher = compile_pattern("^living room .+$", PatternMatchMode::Regex).unwrap();
+
+        assert!(matcher.is_match("living room lamp"));
+        assert!(!matcher.is_match("my living room lamp"));
+        assert!(!matcher.is_match("livingroom lamp"));
+
+        let matcher = compile_pattern("living room*", PatternMatchMode::Regex).unwrap();
+        assert!(matcher.is_match("living room lamp"));
+        assert!(matcher.is_match("my living room lamp"));
     }
 }

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -74,6 +74,10 @@ impl PatternMatcher {
 
 #[async_trait]
 impl Integration for StateLogger {
+    fn wants_runtime_state_changes(&self) -> bool {
+        true
+    }
+
     fn new(
         id: &IntegrationId,
         config: &serde_json::Value,

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 use async_trait::async_trait;
 use chrono::Utc;
 use color_eyre::{eyre::Context, Result};
+use eyre::eyre;
 use jsonptr::PointerBuf;
 use once_cell::sync::OnceCell;
 use regex::Regex;
@@ -44,7 +45,7 @@ enum StateLoggerDatabase {
     Shared,
     Dedicated {
         postgres_url: String,
-        connection: OnceCell<DatabaseConnection>,
+        connection: OnceCell<Result<DatabaseConnection, String>>,
     },
 }
 
@@ -98,21 +99,12 @@ impl Integration for StateLogger {
     }
 
     async fn register(&mut self) -> Result<()> {
-        match self.ensure_database_connection().await {
-            Ok(_) => {
-                info!(
-                    "state_logger[{logger_id}] PostgreSQL connection established using {source}",
-                    logger_id = self.id,
-                    source = self.database_source_label(),
-                );
-            }
-            Err(error) => {
-                error!(
-                    "state_logger[{logger_id}] PostgreSQL connection could not be made using {source}: {error}",
-                    logger_id = self.id,
-                    source = self.database_source_label(),
-                );
-            }
+        if self.ensure_database_connection().await.is_ok() {
+            info!(
+                "state_logger[{logger_id}] PostgreSQL connection established using {source}",
+                logger_id = self.id,
+                source = self.database_source_label(),
+            );
         }
 
         Ok(())
@@ -134,14 +126,7 @@ impl Integration for StateLogger {
 
         let db = match self.ensure_database_connection().await {
             Ok(db) => db,
-            Err(error) => {
-                warn!(
-                    "state_logger[{logger_id}] skipping event write because PostgreSQL connection could not be used via {source}: {error}",
-                    logger_id = self.id,
-                    source = self.database_source_label(),
-                );
-                return Ok(());
-            }
+            Err(_) => return Ok(()),
         };
 
         let previous_devices = &previous.devices.0;
@@ -288,63 +273,47 @@ impl StateLogger {
                 postgres_url,
                 connection,
             } => {
-                if let Some(connection) = connection.get() {
-                    return Ok(connection);
+                if let Some(connection_result) = connection.get() {
+                    return connection_result
+                        .as_ref()
+                        .map_err(|error| eyre!(error.clone()));
                 }
 
                 let mut options = ConnectOptions::new(postgres_url.clone());
                 options.acquire_timeout(Duration::from_secs(2));
 
-                let database_connection = Database::connect(options).await?;
-                ensure_state_logger_events_table(&database_connection).await?;
+                let result: Result<DatabaseConnection, String> = async {
+                    let database_connection = Database::connect(options).await?;
+                    // Ensure the state_logger_events table exists in the dedicated
+                    // database by running only the StateLoggerEvents migration.
+                    crate::db::migrations::ensure_state_logger_events_on_connection(
+                        &database_connection,
+                    )
+                    .await?;
 
-                let _ = connection.set(database_connection);
-                Ok(connection
+                    Ok(database_connection)
+                }
+                .await
+                .map_err(|error: color_eyre::Report| error.to_string());
+
+                if let Err(error) = &result {
+                    warn!(
+                        "state_logger[{logger_id}] PostgreSQL connection could not be made using {source}: {error}",
+                        logger_id = self.id,
+                        source = self.database_source_label(),
+                    );
+                }
+
+                let _ = connection.set(result);
+
+                connection
                     .get()
-                    .expect("dedicated connection should be set"))
+                    .expect("dedicated connection result should be set")
+                    .as_ref()
+                    .map_err(|error| eyre!(error.clone()))
             }
         }
     }
-}
-
-async fn ensure_state_logger_events_table(db: &DatabaseConnection) -> Result<()> {
-    let backend = db.get_database_backend();
-    if !matches!(backend, sea_orm::DbBackend::Postgres) {
-        return Ok(());
-    }
-
-    db.execute(Statement::from_string(
-        backend,
-        r#"CREATE TABLE IF NOT EXISTS state_logger_events (
-            id SERIAL PRIMARY KEY,
-            device_key TEXT NOT NULL,
-            integration_id TEXT NOT NULL,
-            device_id TEXT NOT NULL,
-            device_name TEXT NOT NULL,
-            device_kind TEXT NOT NULL,
-            event_kind TEXT NOT NULL,
-            device_state_json TEXT NOT NULL,
-            value DOUBLE PRECISION NULL,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-        )"#,
-    ))
-    .await?;
-
-    db.execute(Statement::from_string(
-        backend,
-        r#"CREATE INDEX IF NOT EXISTS idx_state_logger_events_device_key
-            ON state_logger_events (device_key)"#,
-    ))
-    .await?;
-
-    db.execute(Statement::from_string(
-        backend,
-        r#"CREATE INDEX IF NOT EXISTS idx_state_logger_events_created_at
-            ON state_logger_events (created_at)"#,
-    ))
-    .await?;
-
-    Ok(())
 }
 
 fn compile_pattern(pattern: &str, mode: PatternMatchMode) -> Result<Regex> {

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -166,10 +166,12 @@ impl Integration for StateLogger {
                 continue;
             }
 
-            let current_value = select_value(current_device, &self.config.value_path);
-            let previous_value = previous_devices
-                .get(device_key)
-                .and_then(|device| select_value(device, &self.config.value_path));
+            let current_state = current_device.get_value();
+            let current_value = select_value(&current_state, &self.config.value_path);
+            let previous_value = previous_devices.get(device_key).and_then(|device| {
+                let previous_state = device.get_value();
+                select_value(&previous_state, &self.config.value_path)
+            });
 
             if previous_value == current_value {
                 debug!(
@@ -189,8 +191,13 @@ impl Integration for StateLogger {
                 value_path = self.config.value_path,
             );
 
-            if let Err(error) =
-                insert_state_logger_event_row(db, current_device, current_value).await
+            if let Err(error) = insert_state_logger_event_row(
+                db,
+                current_device,
+                current_state.to_string(),
+                current_value,
+            )
+            .await
             {
                 warn!(
                     "state_logger[{logger_id}] failed to write event row for {device_key}: {error}",
@@ -203,8 +210,8 @@ impl Integration for StateLogger {
     }
 }
 
-fn select_value(device: &Device, path: &PointerBuf) -> Option<serde_json::Value> {
-    path.as_ref().resolve(&device.get_value()).ok().cloned()
+fn select_value(device_state: &serde_json::Value, path: &PointerBuf) -> Option<serde_json::Value> {
+    path.as_ref().resolve(device_state).ok().cloned()
 }
 
 fn to_numeric_value(value: Option<&serde_json::Value>) -> Option<f64> {
@@ -235,9 +242,9 @@ fn device_kind(device: &Device) -> &'static str {
 async fn insert_state_logger_event_row(
     db: &DatabaseConnection,
     device: &Device,
+    device_state_json: String,
     selected_value: Option<serde_json::Value>,
 ) -> Result<()> {
-    let device_state_json = device.get_value().to_string();
     let value = to_numeric_value(selected_value.as_ref());
     let created_at = Utc::now();
 

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -1,0 +1,373 @@
+use crate::{
+    core::snapshot::{RuntimeSnapshot, SnapshotChanges},
+    db::{get_db_connection, schema::StateLoggerEvents},
+    types::{
+        device::Device,
+        integration::{Integration, IntegrationId},
+    },
+    utils::cli::Cli,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use color_eyre::{eyre::Context, Result};
+use once_cell::sync::OnceCell;
+use jsonptr::PointerBuf;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sea_orm::sea_query::Query;
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, Statement, StatementBuilder};
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+enum PatternMatchMode {
+    #[default]
+    Glob,
+    Regex,
+}
+
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct StateLoggerConfig {
+    source_integration_id: IntegrationId,
+    device_name_pattern: String,
+    #[serde(default)]
+    match_mode: PatternMatchMode,
+    #[serde(default)]
+    postgresql_url: Option<String>,
+    value_path: PointerBuf,
+}
+
+enum StateLoggerDatabase {
+    Shared,
+    Dedicated {
+        postgres_url: String,
+        connection: OnceCell<DatabaseConnection>,
+    },
+}
+
+pub struct StateLogger {
+    id: IntegrationId,
+    config: StateLoggerConfig,
+    compiled_pattern: Regex,
+    database: StateLoggerDatabase,
+}
+
+#[async_trait]
+impl Integration for StateLogger {
+    fn new(
+        id: &IntegrationId,
+        config: &serde_json::Value,
+        _cli: &Cli,
+        _event_tx: crate::types::event::TxEventChannel,
+    ) -> Result<Self> {
+        let config: StateLoggerConfig = serde_json::from_value(config.clone())
+            .wrap_err("Failed to deserialize config of StateLogger integration")?;
+        let compiled_pattern = compile_pattern(&config.device_name_pattern, config.match_mode)
+            .wrap_err("Failed to compile device name pattern for StateLogger integration")?;
+        let database = match &config.postgresql_url {
+            Some(postgres_url) => StateLoggerDatabase::Dedicated {
+                postgres_url: postgres_url.clone(),
+                connection: OnceCell::new(),
+            },
+            None => StateLoggerDatabase::Shared,
+        };
+
+        info!(
+            "state_logger[{logger_id}] loaded from config: source_integration_id={source_integration_id} match_mode={match_mode:?} device_name_pattern={device_name_pattern:?} value_path={value_path} postgres_source={postgres_source}",
+            logger_id = id,
+            source_integration_id = config.source_integration_id,
+            match_mode = config.match_mode,
+            device_name_pattern = config.device_name_pattern,
+            value_path = config.value_path,
+            postgres_source = if config.postgresql_url.is_some() {
+                "state_logger config option postgresql_url"
+            } else {
+                "DATABASE_URL"
+            },
+        );
+
+        Ok(Self {
+            id: id.clone(),
+            config,
+            compiled_pattern,
+            database,
+        })
+    }
+
+    async fn register(&mut self) -> Result<()> {
+        match self.ensure_database_connection().await {
+            Ok(_) => {
+                info!(
+                    "state_logger[{logger_id}] PostgreSQL connection established using {source}",
+                    logger_id = self.id,
+                    source = self.database_source_label(),
+                );
+            }
+            Err(error) => {
+                error!(
+                    "state_logger[{logger_id}] PostgreSQL connection could not be made using {source}: {error}",
+                    logger_id = self.id,
+                    source = self.database_source_label(),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn on_runtime_state_change(
+        &mut self,
+        previous: &RuntimeSnapshot,
+        current: &RuntimeSnapshot,
+        changes: SnapshotChanges,
+    ) -> Result<()> {
+        if !changes.devices && !changes.flattened_scenes && !changes.flattened_groups {
+            debug!(
+                "state_logger[{logger_id}] skipping runtime snapshot change: no relevant device/group/scene updates",
+                logger_id = self.id,
+            );
+            return Ok(());
+        }
+
+        let db = match self.ensure_database_connection().await {
+            Ok(db) => db,
+            Err(error) => {
+                warn!(
+                    "state_logger[{logger_id}] skipping event write because PostgreSQL connection could not be used via {source}: {error}",
+                    logger_id = self.id,
+                    source = self.database_source_label(),
+                );
+                return Ok(());
+            }
+        };
+
+        let previous_devices = &previous.devices.0;
+        for (device_key, current_device) in &current.devices.0 {
+            if current_device.integration_id != self.config.source_integration_id {
+                debug!(
+                    "state_logger[{logger_id}] ignoring {device_key} from integration {device_integration_id}: expecting {expected_integration_id}",
+                    logger_id = self.id,
+                    device_integration_id = current_device.integration_id,
+                    expected_integration_id = self.config.source_integration_id,
+                );
+                continue;
+            }
+
+            if !self.compiled_pattern.is_match(&current_device.name) {
+                debug!(
+                    "state_logger[{logger_id}] ignoring {device_key} name={device_name:?}: pattern did not match",
+                    logger_id = self.id,
+                    device_name = current_device.name,
+                );
+                continue;
+            }
+
+            let current_value = select_value(current_device, &self.config.value_path);
+            let previous_value = previous_devices
+                .get(device_key)
+                .and_then(|device| select_value(device, &self.config.value_path));
+
+            if previous_value == current_value {
+                debug!(
+                    "state_logger[{logger_id}] matched {device_key} name={device_name:?} but value at {value_path} did not change",
+                    logger_id = self.id,
+                    device_name = current_device.name,
+                    value_path = self.config.value_path,
+                );
+                continue;
+            }
+
+            info!(
+                "state_logger[{logger_id}] {device_key} name={device_name:?} path={value_path} previous={previous_value:?} current={current_value:?}",
+                logger_id = self.id,
+                device_key = device_key,
+                device_name = current_device.name,
+                value_path = self.config.value_path,
+            );
+
+            if let Err(error) =
+                insert_state_logger_event_row(db, current_device, current_value).await
+            {
+                warn!(
+                    "state_logger[{logger_id}] failed to write event row for {device_key}: {error}",
+                    logger_id = self.id,
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn select_value(device: &Device, path: &PointerBuf) -> Option<serde_json::Value> {
+    path.as_ref().resolve(&device.get_value()).ok().cloned()
+}
+
+fn to_numeric_value(value: Option<&serde_json::Value>) -> Option<f64> {
+    match value? {
+        serde_json::Value::Number(number) => number.as_f64(),
+        serde_json::Value::Bool(value) => Some(if *value { 1.0 } else { 0.0 }),
+        serde_json::Value::String(text) => text.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn statement<C, S>(db: &C, builder: S) -> Statement
+where
+    C: ConnectionTrait,
+    S: StatementBuilder,
+{
+    db.get_database_backend().build(&builder)
+}
+
+fn device_kind(device: &Device) -> &'static str {
+    if device.is_sensor() {
+        "sensor"
+    } else {
+        "device"
+    }
+}
+
+async fn insert_state_logger_event_row(
+    db: &DatabaseConnection,
+    device: &Device,
+    selected_value: Option<serde_json::Value>,
+) -> Result<()> {
+    let device_state_json = device.get_value().to_string();
+    let value = to_numeric_value(selected_value.as_ref());
+    let created_at = Utc::now();
+
+    db.execute(statement(
+        db,
+        Query::insert()
+            .into_table(StateLoggerEvents::Table)
+            .columns([
+                StateLoggerEvents::DeviceKey,
+                StateLoggerEvents::IntegrationId,
+                StateLoggerEvents::DeviceId,
+                StateLoggerEvents::DeviceName,
+                StateLoggerEvents::DeviceKind,
+                StateLoggerEvents::EventKind,
+                StateLoggerEvents::DeviceStateJson,
+                StateLoggerEvents::Value,
+                StateLoggerEvents::CreatedAt,
+            ])
+            .values_panic([
+                device.get_device_key().to_string().into(),
+                device.integration_id.to_string().into(),
+                device.id.to_string().into(),
+                device.name.clone().into(),
+                device_kind(device).into(),
+                "state_logger".into(),
+                device_state_json.into(),
+                value.into(),
+                created_at.into(),
+            ])
+            .to_owned(),
+    ))
+    .await?;
+
+    Ok(())
+}
+
+impl StateLogger {
+    fn database_source_label(&self) -> &'static str {
+        match self.database {
+            StateLoggerDatabase::Shared => "HomeCTL shared PG connection",
+            StateLoggerDatabase::Dedicated { .. } => {
+                "state_logger config option `postgresql_url`"
+            }
+        }
+    }
+
+    async fn ensure_database_connection(&self) -> Result<&DatabaseConnection> {
+        match &self.database {
+            StateLoggerDatabase::Shared => Ok(get_db_connection()?),
+            StateLoggerDatabase::Dedicated {
+                postgres_url,
+                connection,
+            } => {
+                if let Some(connection) = connection.get() {
+                    return Ok(connection);
+                }
+
+                let mut options = ConnectOptions::new(postgres_url.clone());
+                options.acquire_timeout(Duration::from_secs(2));
+
+                let database_connection = Database::connect(options).await?;
+                ensure_state_logger_events_table(&database_connection).await?;
+
+                let _ = connection.set(database_connection);
+                Ok(connection.get().expect("dedicated connection should be set"))
+            }
+        }
+    }
+}
+
+async fn ensure_state_logger_events_table(db: &DatabaseConnection) -> Result<()> {
+    let backend = db.get_database_backend();
+    if !matches!(backend, sea_orm::DbBackend::Postgres) {
+        return Ok(());
+    }
+
+    db.execute(Statement::from_string(
+        backend,
+        r#"CREATE TABLE IF NOT EXISTS state_logger_events (
+            id SERIAL PRIMARY KEY,
+            device_key TEXT NOT NULL,
+            integration_id TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            device_name TEXT NOT NULL,
+            device_kind TEXT NOT NULL,
+            event_kind TEXT NOT NULL,
+            device_state_json TEXT NOT NULL,
+            value DOUBLE PRECISION NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )"#,
+    ))
+    .await?;
+
+    db.execute(Statement::from_string(
+        backend,
+        r#"CREATE INDEX IF NOT EXISTS idx_state_logger_events_device_key
+            ON state_logger_events (device_key)"#,
+    ))
+    .await?;
+
+    db.execute(Statement::from_string(
+        backend,
+        r#"CREATE INDEX IF NOT EXISTS idx_state_logger_events_created_at
+            ON state_logger_events (created_at)"#,
+    ))
+    .await?;
+
+    Ok(())
+}
+
+fn compile_pattern(pattern: &str, mode: PatternMatchMode) -> Result<Regex> {
+    let regex = match mode {
+        PatternMatchMode::Regex => pattern.to_string(),
+        PatternMatchMode::Glob => glob_to_regex(pattern),
+    };
+
+    Regex::new(&regex).map_err(Into::into)
+}
+
+fn glob_to_regex(pattern: &str) -> String {
+    let mut regex = String::from("^");
+    for character in pattern.chars() {
+        match character {
+            '*' => regex.push_str(".*"),
+            '?' => regex.push('.'),
+            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '[' | ']' | '\\' => {
+                regex.push('\\');
+                regex.push(character);
+            }
+            other => regex.push(other),
+        }
+    }
+    regex.push('$');
+    regex
+}

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -326,7 +326,9 @@ fn compile_pattern(pattern: &str, mode: PatternMatchMode) -> Result<Regex> {
 }
 
 fn glob_to_regex(pattern: &str) -> String {
-    let mut regex = String::from("^");
+    // Do not anchor the generated regex by default. Let callers include
+    // explicit start/end anchors or wildcards in the pattern when desired.
+    let mut regex = String::new();
     for character in pattern.chars() {
         match character {
             '*' => regex.push_str(".*"),
@@ -338,6 +340,58 @@ fn glob_to_regex(pattern: &str) -> String {
             other => regex.push(other),
         }
     }
-    regex.push('$');
     regex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_matches_substring_by_default() {
+        let re = compile_pattern("temp", PatternMatchMode::Glob).unwrap();
+        assert!(re.is_match("my-temp-device"));
+        assert!(re.is_match("temperature"));
+        // spaces in device names should match too
+        assert!(re.is_match("my temp device"));
+        assert!(re.is_match("temp sensor"));
+    }
+
+    #[test]
+    fn glob_wildcards() {
+        let re = compile_pattern("sensor-*", PatternMatchMode::Glob).unwrap();
+        assert!(re.is_match("sensor-1"));
+        // Unanchored patterns match substrings by default
+        assert!(re.is_match("prefix-sensor-1"));
+        assert!(!re.is_match("sensr-1"));
+        // wildcard should also match when device name contains spaces
+        let re2 = compile_pattern("sensor *", PatternMatchMode::Glob).unwrap();
+        assert!(re2.is_match("sensor lamp"));
+        assert!(re2.is_match("prefix sensor lamp"));
+    }
+
+    #[test]
+    fn glob_question_mark() {
+        let re = compile_pattern("dev?ce", PatternMatchMode::Glob).unwrap();
+        assert!(re.is_match("device"));
+        assert!(re.is_match("devXce"));
+        assert!(!re.is_match("devce"));
+        // question mark matches a single character including space
+        let re2 = compile_pattern("dev?ce", PatternMatchMode::Glob).unwrap();
+        assert!(re2.is_match("dev ce"));
+    }
+
+    #[test]
+    fn regex_mode_respects_anchors() {
+        let re = compile_pattern("^sensor-\\d+$", PatternMatchMode::Regex).unwrap();
+        assert!(re.is_match("sensor-123"));
+        assert!(!re.is_match("prefix-sensor-123"));
+        // regex anchors also handle spaces explicitly
+        let re2 = compile_pattern("^living room .+$", PatternMatchMode::Regex).unwrap();
+        assert!(re2.is_match("living room lamp"));
+        assert!(!re2.is_match("my living room lamp"));
+        let re3 = compile_pattern("living room*", PatternMatchMode::Regex).unwrap();
+        assert!(re3.is_match("living room lamp"));
+        assert!(re3.is_match("my living room lamp"));
+    }
 }

--- a/server/src/integrations/state_logger/mod.rs
+++ b/server/src/integrations/state_logger/mod.rs
@@ -1,3 +1,4 @@
+use crate::core::integrations::PLUGIN_STATE_LOGGER;
 use crate::{
     core::snapshot::{RuntimeSnapshot, SnapshotChanges},
     db::{get_db_connection, schema::StateLoggerEvents},
@@ -246,7 +247,7 @@ async fn insert_state_logger_event_row(
                 device.id.to_string().into(),
                 device.name.clone().into(),
                 device_kind(device).into(),
-                "state_logger".into(),
+                PLUGIN_STATE_LOGGER.into(),
                 device_state_json.into(),
                 value.into(),
                 created_at.into(),

--- a/server/src/types/integration.rs
+++ b/server/src/types/integration.rs
@@ -1,3 +1,4 @@
+use crate::core::snapshot::{RuntimeSnapshot, SnapshotChanges};
 use crate::utils::cli::Cli;
 
 use super::{device::Device, event::TxEventChannel};
@@ -153,6 +154,15 @@ pub trait Integration: Send {
         Ok(())
     }
     async fn run_integration_action(&mut self, _payload: &IntegrationActionPayload) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_runtime_state_change(
+        &mut self,
+        _previous: &RuntimeSnapshot,
+        _current: &RuntimeSnapshot,
+        _changes: SnapshotChanges,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/server/src/types/integration.rs
+++ b/server/src/types/integration.rs
@@ -157,6 +157,10 @@ pub trait Integration: Send {
         Ok(())
     }
 
+    fn wants_runtime_state_changes(&self) -> bool {
+        false
+    }
+
     async fn on_runtime_state_change(
         &mut self,
         _previous: &RuntimeSnapshot,

--- a/server/tests/prod_config.rs
+++ b/server/tests/prod_config.rs
@@ -147,6 +147,7 @@ fn wait_for_device_state(
 // ============================================================================
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_server_boots() {
     let server = start_prod_simulation();
 
@@ -178,6 +179,7 @@ fn prod_config_server_boots() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_has_expected_config() {
     let server = start_prod_simulation();
 
@@ -255,6 +257,7 @@ fn prod_config_has_expected_config() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_scene_activation() {
     let server = start_prod_simulation();
 
@@ -302,6 +305,7 @@ fn prod_config_scene_activation() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_night_scene() {
     let server = start_prod_simulation();
 
@@ -348,6 +352,7 @@ fn prod_config_night_scene() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_arrive_home_routine() {
     let server = start_prod_simulation();
 
@@ -383,6 +388,7 @@ fn prod_config_arrive_home_routine() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_leave_home_routine() {
     let server = start_prod_simulation();
 
@@ -419,6 +425,7 @@ fn prod_config_leave_home_routine() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_nightlight_cycle() {
     let server = start_prod_simulation();
 
@@ -464,6 +471,7 @@ fn prod_config_nightlight_cycle() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_staircase_motion_upstairs() {
     let server = start_prod_simulation();
 
@@ -508,6 +516,7 @@ fn prod_config_staircase_motion_upstairs() {
 }
 
 #[test]
+#[cfg_attr(not(has_prod_config), ignore)]
 fn prod_config_group_scoped_activation() {
     let server = start_prod_simulation();
 

--- a/server/tests/prod_config.rs
+++ b/server/tests/prod_config.rs
@@ -249,7 +249,8 @@ fn prod_config_has_expected_config() {
     for integration in int_list {
         let plugin = integration["plugin"].as_str().unwrap();
         assert_ne!(
-            plugin, "mqtt",
+            plugin,
+            homectl_server::core::integrations::PLUGIN_MQTT,
             "MQTT integration '{}' should have been converted to dummy",
             integration["id"]
         );

--- a/ui/package.json
+++ b/ui/package.json
@@ -109,10 +109,5 @@
     "vite": "8.0.8"
   },
   "version": "1.0.0",
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.7",
-      "@types/react-dom": "19.2.3"
-    }
-  }
+  "packageManager": "pnpm@11.5.0"
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,3 +1,202 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: '>=11.0.0 <12.0.0'
+        version: 11.5.0
+      pnpm:
+        specifier: '>=11.0.0 <12.0.0'
+        version: 11.5.0
+
+packages:
+
+  '@pnpm/exe@11.5.0':
+    resolution: {integrity: sha512-4hzOXq1HHrNPjwI8k1rt7Ot/Yrdx1JX3pn/L/M95ii1gid1Q6ZK6dVg4+gbSgUdPsYmYDZ4/Yfc0A7vd5C0ndg==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.5.0':
+    resolution: {integrity: sha512-NV9HdzzCB0epuI9LqZZeTaqjH3OweNQSQCS76GzEkFxJHS9e5Gvu7tgex91gxVL7bCZ+R4yr/3d3yexBFtr2ug==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.5.0':
+    resolution: {integrity: sha512-vH83rRx4iPk/bwm9pBVCn+5hXbcQI66I/4zk6Vc09SusJgTqOdbN4U6VhMcGIqSEdr901ksYGCyIbMv7f6Guew==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.5.0':
+    resolution: {integrity: sha512-2nOnMW1rSwGv22q2yZz1HlGT3ly/Ij8wUlX0NB4n+Krx7nETRHA3MgWsbkVejxHknDcTulRVudAghuX9rgrXcw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.5.0':
+    resolution: {integrity: sha512-ONOC1Mg0JusHtjzkRlre9di1QO+GAjy4HP7jMjDx21yGhrSheNdUweTXbekMH1EflRd19kTU6d8M3zewJFPtVg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.5.0':
+    resolution: {integrity: sha512-od0ALdTxs4A7s5vAH5q2l2phzCJb98+PVOW1rq7BGpWGeYxQ+EwvL+vq0KaO6iLsn/eVVoncCkgZ/k6QNYuTgw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.5.0':
+    resolution: {integrity: sha512-9HqbI80FjVVqFx4+EPxYYNfeP9Sx69W6kYqUDvOJn9G7RJ/2NNNQ898cVHTMpXlW1/PrMEcijmdpa/NjZIrWiQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.5.0':
+    resolution: {integrity: sha512-Q89CQqFGAsWmfvHZs5Kbbar45q3GBYtfAdPUCiVMVNJoLi3dsBS2LCvUq8ak3AufkFDaJBpvhaFcDP2M1NXr3A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.5.0:
+    resolution: {integrity: sha512-2/zE+Bz0hZev1Lw5H/3xLBHxqfuDo5W/prCi2cwv2P/rr9scy9UpYyFT95OQTCYVt/Cf4aNFRz/Rw1hFFyqOsQ==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.5.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.5.0
+      '@pnpm/linux-x64': 11.5.0
+      '@pnpm/linuxstatic-arm64': 11.5.0
+      '@pnpm/linuxstatic-x64': 11.5.0
+      '@pnpm/macos-arm64': 11.5.0
+      '@pnpm/win-arm64': 11.5.0
+      '@pnpm/win-x64': 11.5.0
+
+  '@pnpm/linux-arm64@11.5.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.5.0':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.5.0':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.5.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.5.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.5.0':
+    optional: true
+
+  '@pnpm/win-x64@11.5.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.5.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  canvas: true
+  sharp: true
+overrides:
+  '@types/react': 19.2.7
+  '@types/react-dom': 19.2.3


### PR DESCRIPTION
adds state_logger integration for logging state changes into a database. Features pattern matching of devices (by name) and optional postgres db connection string if the data needs to be stored somewhere else than the config database.

Config in json can look like below, for example:

``` json
{
  "id": "motion_logger",
  "plugin": "state_logger",
  "config": {
    "device_name_pattern": "Motion sensor*",
    "match_mode": "glob",
    "source_integration_id": "mqtt",
    "value_path": "/value"
  },
  "enabled": true
}
```

And database entries look like below

<img width="1098" height="315" alt="image" src="https://github.com/user-attachments/assets/f2543c51-62b5-4216-aa18-6837f51bedc1" />